### PR TITLE
fix(vulkan): option only visible if nvidia driver installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ All notable changes to this project will be documented in this file (focus on ch
 	- add translation in Pegasus parameterlists (in cpp code)
 	- New "qmlutils" component to manage horizontal scrolling
 	- add icons displayed for generix x-box pad for xbox 360/One/Series
-	- add option to force vulkan video driver
+	- add option to force vulkan video driver (only for nvidia-driver)
 	- add translation for vulkan video driver menu
 
 - Fixes:

--- a/src/frontend/menu/settings/SettingsMain.qml
+++ b/src/frontend/menu/settings/SettingsMain.qml
@@ -258,8 +258,9 @@ FocusScope {
                 ToggleOption {
                     id: optVideoDriver
 
-                    label: qsTr("Video Driver") + api.tr
+                    label: qsTr("Vulkan video driver") + api.tr
                     note: qsTr("Force video driver to Vulkan") + api.tr
+                    visible: api.internal.recalbox.getStringParameter("boot.nvidia-driver") === "true" ? true : false // only visible if have Nvidia Gpu activated
                     checked: api.internal.recalbox.getBoolParameter("system.video.driver.vulkan")
                     onCheckedChanged: {
                         api.internal.recalbox.setBoolParameter("system.video.driver.vulkan",checked);


### PR DESCRIPTION
vulkan configuration for intel conflicts with new drivers and Nividia gpu 
vulkan intel is therefore for the moment deactivated