### PR TITLE
fix(virtualkeyboard): activated by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file (focus on ch
 	- wifi-first-activation-not-list-proposed #[13]
 	- fix up to option WifiNetwork not work in setting menu if wifi enabled
 	- update translation fr for color setting and axis controller
+	- virtualkeyboard activate by default #[33]
 
 - Features:
 	- add system videos from 'share/videos' directory in collections (to be used with Shinretro theme)

--- a/src/backend/AppSettings.cpp
+++ b/src/backend/AppSettings.cpp
@@ -146,7 +146,7 @@ General::General()
     , portable(false)
     , fullscreen(true)
     , mouse_support(false)
-	, virtualkeyboard_support(false)
+	, virtualkeyboard_support(true)
     , locale() // intentionally blank
     , theme(DEFAULT_THEME)
 {}


### PR DESCRIPTION
[b28] Virtual keyboard demand by Aldebaran
https://gitlab.com/pixl-os/pixl/-/issues/33