### PR TITLE
fix(gamepadmanager): to avoid to trim controller name that generate missmatching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file (focus on ch
 ## [pixL-master] - 2023-MM-DD - v0.1.X
 - Fixes:
 	- check more regularly json from temp and change delay from timer (check after 20s)
+	- fix gamepadManager to avoid to trim controller name that generate missmatching
+
 - Features:
 	- add display in GB for online update >= than 1024 Mo
 

--- a/src/backend/model/internal/GamepadManager.cpp
+++ b/src/backend/model/internal/GamepadManager.cpp
@@ -310,12 +310,13 @@ void GamepadManager::bkOnIndexChanged(int device_idx1, int device_idx2)
 		//change in recalbox.conf also
 		//Get existing line
 		std::string initialPadPegasusValue = RecalboxConf::Instance().GetPadPegasus(device_id);
+        Log::debug(m_log_tag, LOGMSG("initialPadPegasusValue: %1").arg(QString::fromStdString(initialPadPegasusValue)));
 		std::string path = "";
 		std::string uuid = "";
 		std::string name = "";
 		std::string sdlidx = "";
 		//Get info to reconstruct the line
-		Strings::SplitInFour(initialPadPegasusValue, '|', uuid, name, path, sdlidx, true);
+        Strings::SplitInFour(initialPadPegasusValue, '|', uuid, name, path, sdlidx, false);
 		//set to new index
 		sdlidx = std::to_string(device_idx2);
 		std::string newPadPegasusValue = "";


### PR DESCRIPTION

fix(gamepadmanager): to avoid to trim controller name that generate missmatching

