### PR TITLE
rework-xbox-controllers-management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file (focus on change done on recalbox-integration branch).
 
-
-## [pixL-master] - 2023-MM-DD - v0.1.X
+## [pixL-master] - 2023-04-XX - v0.1.X
 - Fixes:
 	- check more regularly json from temp and change delay from timer (check after 20s)
 	- fix gamepadManager to avoid to trim controller name that generate missmatching
@@ -12,8 +11,9 @@ All notable changes to this project will be documented in this file (focus on ch
 	- remove recopy of data from collections to games for optimization
 	- improvement of caches for qml and js
 	- menu section deactivated from removing xow
-	- improve methods to check battery capacity since xow/xpadneo integration
+	- improve methods to check battery capacity since xone/xpadneo integration
 	- fix to display better the icon used for xbox one/series controllers
+	- fix to change way to detect dualsense ps5 controller using new firmware to have a best display of icon in bluetooth menu
 
 - Features:
 	- add display in GB for online update >= than 1024 Mo
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file (focus on ch
 	- manage 'deviceLayout' parameter from es_input.cfg to force layout usage by GUID but also for icons (except in bluetooth interface where it's not yet possible)
 	- add icon for ps5 controllers
 	- refine icons affectation for xbox360, ps5 and xbox
-	- Add redshift option 
+	- add redshift option
+	- add autopair option for bluetooth controllers
+	- request reboot if bluetooth/autopair parameters changed
 
 ## [pixL-master] - 2023-01-21 - v0.1.1
 - Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file (focus on ch
 	- remove 'sortfilterproxymodel' submodule as remote one to have it locally and simplify maintenance
 	- remove recopy of data from collections to games for optimization
 	- improvement of caches for qml and js
+	- menu section deactivated from removing xow
+	- improve methods to check battery capacity since xow/xpadneo integration
+	- fix to display better the icon used for xbox one/series controllers
 
 - Features:
 	- add display in GB for online update >= than 1024 Mo

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1303,7 +1303,7 @@ Window {
         ListElement { icon: "\uf2f0"; keywords: "xbox series"; type:"controller"; iconfont: "awesome"} //as XBOX one for the moment, need icon for series
         ListElement { icon: "\uf2ee"; keywords: "xbox,microsoft"; type:"controller"; iconfont: "awesome"} //as XBOX for the moment
 
-        ListElement { icon: "\uf0cf"; keywords: "ps5,playstation 5,dualsense,wireless controller"; type:"controller"; iconfont: "awesome"; layout: "ps5"} // add wireless controller as usual PS name used by Sony
+        ListElement { icon: "\uf0cf"; keywords: "ps5,playstation 5,dualsense"; type:"controller"; iconfont: "awesome"; layout: "ps5"} // add wireless controller as usual PS name used by Sony
         ListElement { icon: "\uf2ca"; keywords: "ps4,playstation 4,dualshock 4,wireless controller"; type:"controller"; iconfont: "awesome"; layout: "ps4"} // add wireless controller as usual PS name used by Sony
         ListElement { icon: "\uf2c9"; keywords: "ps3,playstation 3,dualshock 3"; type:"controller"; iconfont: "awesome"}
         ListElement { icon: "\uf2c8"; keywords: "ps2,playstation 2,dualshock 2"; type:"controller"; iconfont: "awesome"}

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1299,7 +1299,7 @@ Window {
 
         //CONTROLLERS PART
         ListElement { icon: "\uf2ef"; keywords: "x360,xbox360,xbox 360,x-box 360"; type:"controller"; iconfont: "awesome"; layout: "xbox360"} //as XBOX for the moment, need icon for 360
-        ListElement { icon: "\uf2f0"; keywords: "xboxone,xbox one,x-box one"; type:"controller"; iconfont: "awesome"; layout: "xboxone"}
+        ListElement { icon: "\uf2f0"; keywords: "xboxone,xbox one,x-box one,xbox wireless"; type:"controller"; iconfont: "awesome"; layout: "xboxone"}
         ListElement { icon: "\uf2f0"; keywords: "xbox series"; type:"controller"; iconfont: "awesome"} //as XBOX one for the moment, need icon for series
         ListElement { icon: "\uf2ee"; keywords: "xbox,microsoft"; type:"controller"; iconfont: "awesome"} //as XBOX for the moment
 

--- a/src/frontend/menu/settings/AdvancedControllersConf.qml
+++ b/src/frontend/menu/settings/AdvancedControllersConf.qml
@@ -113,7 +113,25 @@ FocusScope {
                     }
                     symbol: "\uf29a"
                     onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optBluetoothAutopair
+                }
+                ToggleOption {
+                    id: optBluetoothAutopair
+                    //controllers.bluetooth.autopair=1 by default
+                    label: qsTr("Enable Auto pairing") + api.tr
+                    note: qsTr("Enable support of autopairing during 5 min after boot for bluetooth controllers.\nPlease reboot to apply change") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("controllers.bluetooth.autopair",true);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("controllers.bluetooth.autopair",true)){
+                            api.internal.recalbox.setBoolParameter("controllers.bluetooth.autopair",checked);
+                            //need to reboot to take change into account !
+                            needReboot = true;
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
                     KeyNavigation.down: optBluetoothScanMethods
+                    visible: optBluetoothControllers.checked
                 }
                 MultivalueOption {
                     id: optBluetoothScanMethods
@@ -415,7 +433,7 @@ FocusScope {
                         api.internal.recalbox.setBoolParameter("controllers.joycond.enabled",checked);
                     }
                     onFocusChanged: container.onFocus(this)
-                    KeyNavigation.down: optXboxOneControllers
+                    //KeyNavigation.down: optXboxOneControllers
 
                 }
                 // Section deactivated from removing xow - keep code to easily reactivate if needed

--- a/src/frontend/menu/settings/AdvancedControllersConf.qml
+++ b/src/frontend/menu/settings/AdvancedControllersConf.qml
@@ -107,9 +107,13 @@ FocusScope {
                     // note: qsTr("Enable support for bluetooth controllers") + api.tr
 
 
-                    checked: api.internal.recalbox.getBoolParameter("controllers.bluetooth.enabled");
+                    checked: api.internal.recalbox.getBoolParameter("controllers.bluetooth.enabled",true);
                     onCheckedChanged: {
-                        api.internal.recalbox.setBoolParameter("controllers.bluetooth.enabled",checked);
+                        if(checked !== api.internal.recalbox.getBoolParameter("controllers.bluetooth.enabled",true)){
+                            api.internal.recalbox.setBoolParameter("controllers.bluetooth.enabled",checked);
+                            //need to reboot to take change into account !
+                            needReboot = true;
+                        }
                     }
                     symbol: "\uf29a"
                     onFocusChanged: container.onFocus(this)

--- a/src/frontend/menu/settings/AdvancedControllersConf.qml
+++ b/src/frontend/menu/settings/AdvancedControllersConf.qml
@@ -418,7 +418,8 @@ FocusScope {
                     KeyNavigation.down: optXboxOneControllers
 
                 }
-                SectionTitle {
+                // Section deactivated from removing xow - keep code to easily reactivate if needed
+                /*SectionTitle {
                     text: qsTr("Xbox One/Series controllers") + api.tr
                     first: true
                     symbol:"\uf34c"
@@ -446,7 +447,7 @@ FocusScope {
                         api.internal.recalbox.setBoolParameter("controllers.xow.enabled",checked);
                     }
                     onFocusChanged: container.onFocus(this)
-                }
+                }*/
                 Item {
                     width: parent.width
                     height: implicitHeight + vpx(30)


### PR DESCRIPTION
- menu section deactivated from removing xow
	- improve methods to check battery capacity since xone/xpadneo integration
	- fix to display better the icon used for xbox one/series controllers
	- fix to change way to detect dualsense ps5 controller using new firmware to have a best display of icon in bluetooth menu
- manage 'deviceLayout' parameter from es_input.cfg to force layout usage by GUID but also for icons (except in bluetooth interface where it's not yet possible)
	- add icon for ps5 controllers
	- refine icons affectation for xbox360, ps5 and xbox
	- add autopair option for bluetooth controllers
	- request reboot if bluetooth/autopair parameters changed