### PR TITLE
change way to manage refresh of update + dev feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Change Log
 All notable changes to this project will be documented in this file (focus on change done on recalbox-integration branch).
 
+## [pixL-master] - 2023-XX-XX - vX.X.X
+- Features:
+	- add possibility to use 'dev' updates to help testing of OS update by developers
+	- use recalbox.conf "updates." parameters now
+
+- Fixes:
+	- add support of "-v" and "v" tags in updates versions in upper case also now
+	- use recalbox.conf to store last check time for updates
+
 ## [pixL-master] - 2023-11-13 - v0.1.5
 - Features:
 	- bump libretro-common using commit 01c612 - 18-08-2023

--- a/src/backend/model/internal/updates/Updates.cpp
+++ b/src/backend/model/internal/updates/Updates.cpp
@@ -93,7 +93,7 @@ QString getVersionString(const QString rawVersion){
     // 'retroarch-v1.9.14 test" -> [1,9,14]
     //Other string format will be not OK and can't be well parsed
 
-    QRegularExpression regex("(-v|v)(\\d+.*?)(-|\\s|$)");// to get between "v" or "-v" and ("-" or end of line or space)
+    QRegularExpression regex("(-v|v|-V|V)(\\d+.*?)(-|\\s|$)");// to get between "v" or "-v" and ("-" or end of line or space) and in upper case also now.
 
     QRegularExpressionMatch match = regex.match(rawVersion);
     Log::debug("getVersionNumbers", LOGMSG("versionString: %1").arg(rawVersion));

--- a/src/frontend/dialogs/RebootDialog.qml
+++ b/src/frontend/dialogs/RebootDialog.qml
@@ -27,7 +27,7 @@ GenericOkCancelDialog
 //    symbol: "\u21BB"
 
     onAccept: {
-        api.memory.unset("repoStatusRefreshTime");
+        api.internal.recalbox.setStringParameter("updates.lastchecktime", "")
         api.internal.system.reboot();
     }
 }

--- a/src/frontend/dialogs/RestartDialog.qml
+++ b/src/frontend/dialogs/RestartDialog.qml
@@ -29,7 +29,7 @@ GenericOkCancelDialog
 //    symbol: "\u21BB"
 
     onAccept: {
-        api.memory.unset("repoStatusRefreshTime");
+        api.internal.recalbox.setStringParameter("updates.lastchecktime", "")
         api.internal.system.restart();
     }
 }

--- a/src/frontend/dialogs/ShutdownDialog.qml
+++ b/src/frontend/dialogs/ShutdownDialog.qml
@@ -26,7 +26,7 @@ GenericOkCancelDialog
 //    symbol: "\u23FB"
 
     onAccept: {
-        api.memory.unset("repoStatusRefreshTime");
+        api.internal.recalbox.setStringParameter("updates.lastchecktime", "")
         api.internal.system.shutdown();
     }
 

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -378,7 +378,7 @@ Window {
             }
             function onRequestQuit() {
                 theme.source = "";
-                api.memory.unset("repoStatusRefreshTime");
+                api.internal.recalbox.setStringParameter("updates.lastchecktime", "")
                 api.internal.system.quit();
             }
         }
@@ -1148,7 +1148,8 @@ Window {
             var before = api.memory.get("repoStatusRefreshTime");
             console.log("repoStatusRefreshTime restored : ", before);
             //check if we restart the front end or not in the last 30 minutes
-            //if before is empty, updates will be checked
+                var before = api.internal.recalbox.getStringParameter("updates.lastchecktime")
+                //console.log("updates.lastchecktime read: ", before);
             //if now is upper or equal than before + interval, updates will be checked
             //if now is less than before + interval, we do nothing
             if(Date.now() < (parseInt(before) + interval)){
@@ -1156,8 +1157,8 @@ Window {
             }
             else {
                 //store info in memory and launch check of updates
-                console.log("repoStatusRefreshTime saved :    ", Date.now());
-                api.memory.set("repoStatusRefreshTime", Date.now());
+                    //console.log("updates.lastchecktime write: ", Date.now());
+                    api.internal.recalbox.setStringParameter("updates.lastchecktime", Date.now())
                 //loop to launch download of all json repository files
                 for(var i = 0;i < componentsListModel.count; i++){
                     if((typeof(componentsListModel.get(i).repoUrl) !== "undefined") && (componentsListModel.get(i).repoUrl !== ""))

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1113,16 +1113,23 @@ Window {
         running: true
         triggeredOnStart: true
         onTriggered: {
-            //check version via recalbox.version
-            //if "beta"/"release" terms are found
-            isBeta = (api.internal.system.run("grep -i 'beta' /recalbox/recalbox.version") === "") ? false : true
-            isRelease = (api.internal.system.run("grep -i 'release' /recalbox/recalbox.version") === "") ? false : true
-            if(isRelease === true){// to propose release or pre-release in priority
-                componentsListModel.append({ componentName: "pixL-OS", repoUrl:"https://updates.pixl-os.com/release-pixl-os.json",icon: "qrc:/frontend/assets/logo.png", picture: "qrc:/frontend/assets/backgroundpixl.png", multiVersions: false});
+            //check if not dev version is requested
+            if(api.internal.recalbox.getStringParameter("updates.type") !== "dev"){
+                //check version via recalbox.version
+                //if "beta"/"release" terms are found
+                isBeta = (api.internal.system.run("grep -i 'beta' /recalbox/recalbox.version") === "") ? false : true
+                isRelease = (api.internal.system.run("grep -i 'release' /recalbox/recalbox.version") === "") ? false : true
+                if(isRelease === true){// to propose release or pre-release in priority
+                    componentsListModel.append({ componentName: "pixL-OS", repoUrl:"https://updates.pixl-os.com/release-pixl-os.json",icon: "qrc:/frontend/assets/logo.png", picture: "qrc:/frontend/assets/backgroundpixl.png", multiVersions: false});
+                }
+                else if(isBeta === true){ // to propose beta only if we have already a beta version installed
+                    componentsListModel.append({ componentName: "pixL-OS (Beta)", repoUrl:"https://updates.pixl-os.com/beta-pixl-os.json",icon: "qrc:/frontend/assets/logobeta.png", picture: "qrc:/frontend/assets/backgroundpixl.png", multiVersions: false});
+                }
             }
-            else if(isBeta === true){ // to propose beta only if we have already a beta version installed
-                componentsListModel.append({ componentName: "pixL-OS (Beta)", repoUrl:"https://updates.pixl-os.com/beta-pixl-os.json",icon: "qrc:/frontend/assets/logobeta.png", picture: "qrc:/frontend/assets/backgroundpixl.png", multiVersions: false});
+            else{// for dev testing only about updates
+                componentsListModel.append({ componentName: "pixL-OS (Dev)", repoUrl:"https://updates.pixl-os.com/dev-pixl-os.json",icon: "qrc:/frontend/assets/logobeta.png", picture: "qrc:/frontend/assets/backgroundpixl.png", multiVersions: false});
             }
+
             //stop timer
             addUpdateTimer.stop();
             //start other timers


### PR DESCRIPTION
- Features:
	- add possibility to use 'dev' updates to help testing of OS update by developers
	- use recalbox.conf "updates." parameters now

- Fixes:
	- add support of "-v" and "v" tags in updates versions in upper case also now
	- use recalbox.conf to store last check time for updates