### PR TITLE
retroachievements quick fixes and rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ All notable changes to this project will be documented in this file (focus on ch
 	- use recalbox.conf "updates." parameters now
 	- add docked mode options in advanced emulator settings
 	- add more log at start for QT Library Information about version and paths
+	- add token saving also in recalbox.conf parameters now for configgen/emulators
+	- use hash of login+password now to discriminate cache and change about retroachievement token 
 
 - Fixes:
 	- add support of "-v" and "v" tags in updates versions in upper case also now
 	- use recalbox.conf to store last check time for updates
 	- start to change some QML import for QT 5.15 (tested with new buildroot version also)
+	- quick fix for retroachievement display to restore previous behavior due to issue with hashlibrary parsing and when 'mass' hash calculation/check is deactivated.
 
 ## [pixL-master] - 2023-11-13 - v0.1.5
 - Features:

--- a/src/backend/model/gaming/Game.cpp
+++ b/src/backend/model/gaming/Game.cpp
@@ -154,7 +154,7 @@ void Game::checkRetroAchievements_slot()
         try{
             //const providers::retroAchievements::Metadata metahelper(log_tag);
             //get GameID from cache and calculating the hash
-            m_metahelper.set_RaHash_And_GameID_from_hashlibrary_or_cache(*this, false);
+            m_metahelper.set_RaHash_And_GameID(*this, false);
             //emit signal to alert front-end about end of changes
             emit raHashChanged();
             emit raGameIDChanged();
@@ -226,7 +226,7 @@ void Game::initRetroAchievements_slot()
     try{
     //const providers::retroAchievements::Metadata metahelper(log_tag);
 	//get all from network for the moment to have last information / one function called for the moment
-    m_metahelper.fill_Ra_from_network_or_cache(*this, false);
+    m_metahelper.fill_Ra_details_and_status(*this, false);
 	//emit signal to alert front-end about end of update
 	emit retroAchievementsInitialized();
     }
@@ -250,7 +250,7 @@ void Game::updateRetroAchievements_slot()
     try{
         //const providers::retroAchievements::Metadata metahelper(log_tag);
 		//get all from network for the moment to have last information / one function called for the moment
-        m_metahelper.fill_Ra_from_network_or_cache(*this, true);
+        m_metahelper.fill_Ra_details_and_status(*this, true);
 		//emit signal to alert front-end about end of update
 		emit retroAchievementsChanged();
     }

--- a/src/backend/providers/retroachievements/RetroAchievementsMetadata.h
+++ b/src/backend/providers/retroachievements/RetroAchievementsMetadata.h
@@ -27,9 +27,9 @@ class Metadata {
 public:
     explicit Metadata(QString);
     //function to set Hash and GameID for game object (return gameid)
-    int set_RaHash_And_GameID_from_hashlibrary_or_cache(model::Game&, bool) const;
+    int set_RaHash_And_GameID(model::Game&, bool) const;
     //function to set Ra Details for game object
-    void fill_Ra_from_network_or_cache(model::Game&, bool) const;
+    void fill_Ra_details_and_status(model::Game&, bool) const;
     const QString& log_tag() const { return m_log_tag; }
     //function to build md5/gameid hash map from hash library json url provided by retroachievements.org
     void build_md5_db(QString hashlibrary_url) const;


### PR DESCRIPTION
features:
- add token saving also in recalbox.conf parameters now for configgen/emulators
- use hash of login+password now to discriminate cache and change about retroachievement token 
fixes:
- fix for retroachievement display to restore previous behavior due to issue with hashlibrary parsing and when 'mass' hash calculation/check is deactivated.
