### PR TITLE
pixl upgrade/update improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to this project will be documented in this file (focus on ch
 	- add new menu for emulators configuration
 	- add dedicated qml(menu) for suyu
 	- add vsync option for suyu
+	- pixL upgrade/update improvements:
+	    - in scriptmanager, add dedicated thread to execute script as install.sh and without UI blocking
+	    - use "shutdown -r now" command to do a full reboot now
+	    - change to well display status immediately when we load Updates view
+	    - add popup at start when full upgrade is done or failed
+	    - add management to resume download if file already exists in download directory
+	    - fix display using 'long qint64' and not just 'int' for assets size
+	    - add feature to be able to change download directory for update including size & raw format management
+	    - not count file not well downloaded now (to detect better issues)
+	    - add feature to be able to test updates from personal repo for dev purposes (using updates.devuser parameter)
 
 ## [pixL-master] - 2024-03-05 - v0.1.6
 - Features:

--- a/src/backend/DownloadManager.cpp
+++ b/src/backend/DownloadManager.cpp
@@ -121,7 +121,7 @@ void DownloadManager::append(const QUrl &url, const QString &filename)
     append(url, filename, 0);
 }
 
-void DownloadManager::append(const QUrl &url, const QString &filename, const int filesize)
+void DownloadManager::append(const QUrl &url, const QString &filename, const qint64 filesize)
 {
     //Log::debug("DownloadManager", LOGMSG("append('%1','%2')").arg(url.toString(),filename));
     if (downloadQueue.isEmpty()){
@@ -178,7 +178,7 @@ void DownloadManager::startNextDownload()
 
     QUrl url = downloadQueue.dequeue();
     QString filename = filenameQueue.dequeue();
-    int targetedFileSize = filesizeQueue.dequeue();
+    qint64 targetedFileSize = filesizeQueue.dequeue();
 
     if(filename == ""){
         filename = saveFileName(url);
@@ -286,7 +286,7 @@ void DownloadManager::downloadProgress(qint64 bytesReceived, qint64 bytesTotal)
 void DownloadManager::downloadFinished()
 {
     //Log::debug("DownloadManager", LOGMSG("downloadFinished()"));
-
+    Log::debug("DownloadManager", LOGMSG("downloadFinished() of %1 Bytes ").arg(QString::number(output.size())));
     output.close();
 
     if (currentDownload->error()) {

--- a/src/backend/DownloadManager.cpp
+++ b/src/backend/DownloadManager.cpp
@@ -316,7 +316,6 @@ void DownloadManager::downloadFinished()
         } else {
             setMessage(QString("%1 downloaded").arg(output.fileName()));
             Log::debug("DownloadManager", LOGMSG("%1 downloaded").arg(output.fileName()));
-            ++downloadedCount;
             Log::debug("DownloadManager", LOGMSG("outputTargetedSize : %1").arg(QString::number(outputTargetedSize)));
             Log::debug("DownloadManager", LOGMSG("output.size() : %1").arg(QString::number(output.size())));
             if((outputTargetedSize != 0) && (outputTargetedSize != output.size())){
@@ -326,6 +325,9 @@ void DownloadManager::downloadFinished()
                 setError(4);
                 //we remove in this case to retry
                 output.remove();
+            }
+            else{
+                ++downloadedCount;
             }
         }
     }

--- a/src/backend/DownloadManager.h
+++ b/src/backend/DownloadManager.h
@@ -92,6 +92,7 @@ private:
     QQueue<qint64> filesizeQueue;
     QNetworkReply *currentDownload = nullptr;
     QFile output;
+    qint64 outputTargetedSize;
     QElapsedTimer downloadTimer;
 
     qint64 value = 0;

--- a/src/backend/DownloadManager.h
+++ b/src/backend/DownloadManager.h
@@ -57,7 +57,7 @@ class DownloadManager: public QObject
     Q_OBJECT
 public:
     explicit DownloadManager(QObject *parent = nullptr);
-    void append(const QUrl &url, const QString &filename, const int filesize);
+    void append(const QUrl &url, const QString &filename, const qint64 filesize);
     void append(const QUrl &url, const QString &filename);
     void append(const QStringList &urls);
     static QString saveFileName(const QUrl &url);
@@ -89,7 +89,7 @@ private:
     QNetworkAccessManager manager;
     QQueue<QUrl> downloadQueue;
     QQueue<QString> filenameQueue;
-    QQueue<int> filesizeQueue;
+    QQueue<qint64> filesizeQueue;
     QNetworkReply *currentDownload = nullptr;
     QFile output;
     QElapsedTimer downloadTimer;

--- a/src/backend/DownloadManager.h
+++ b/src/backend/DownloadManager.h
@@ -57,6 +57,7 @@ class DownloadManager: public QObject
     Q_OBJECT
 public:
     explicit DownloadManager(QObject *parent = nullptr);
+    void append(const QUrl &url, const QString &filename, const int filesize);
     void append(const QUrl &url, const QString &filename);
     void append(const QStringList &urls);
     static QString saveFileName(const QUrl &url);
@@ -88,6 +89,7 @@ private:
     QNetworkAccessManager manager;
     QQueue<QUrl> downloadQueue;
     QQueue<QString> filenameQueue;
+    QQueue<int> filesizeQueue;
     QNetworkReply *currentDownload = nullptr;
     QFile output;
     QElapsedTimer downloadTimer;

--- a/src/backend/DownloadManager.h
+++ b/src/backend/DownloadManager.h
@@ -66,6 +66,7 @@ public:
     float statusProgress = 0.0;
     int downloadedCount = 0;
     int totalCount = 0;
+    int statusError = 0; //0: no error, 1: error during download, 2: error to save downloaded file
 
 signals:
     void finished();
@@ -80,6 +81,7 @@ private:
     void setMessage(const QString &m);
     void setSpeed(const QString &m);
     void setStatus(qint64 val, qint64 max);
+    void setError(qint64 val);
     bool isHttpRedirect() const;
     QUrl reportRedirect();
 

--- a/src/backend/ScriptRunner.cpp
+++ b/src/backend/ScriptRunner.cpp
@@ -82,7 +82,7 @@ void ScriptRunner::run(ScriptEvent event, const QStringList& args)
 {
     static const HashMap<ScriptEvent, QString, EnumHash> SCRIPT_DIRS {
         { ScriptEvent::QUIT, QStringLiteral("quit") },
-        { ScriptEvent::REBOOT, QStringLiteral("reboot") },
+        { ScriptEvent::REBOOT, QStringLiteral("shutdown -r now") }, //use shutdown -r and not reboot to well reboot and well initialize framebuffer for example
 		{ ScriptEvent::RESTART, QStringLiteral("restart") },
         { ScriptEvent::SHUTDOWN, QStringLiteral("shutdown") },
         { ScriptEvent::CONFIG_CHANGED, QStringLiteral("config-changed") },

--- a/src/backend/model/internal/updates/Updates.cpp
+++ b/src/backend/model/internal/updates/Updates.cpp
@@ -573,6 +573,11 @@ void Updates::launchComponentInstallation_slot(QString componentName, const QStr
                     QObject::connect(&downloadManager[m_updates[foundIndex].m_downloaderIndex], &DownloadManager::finished, &loop, &QEventLoop::quit);
                     loop.exec();
                     Log::debug(log_tag, LOGMSG("launchComponentInstallation_slot: %1").arg(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusMessage));
+                    if(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusError > 0){
+                        Log::debug(log_tag, LOGMSG("launchComponentInstallation_slot: finished with error - exit status: %1").arg(QString::number(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusError)));
+                        this->m_updates[foundIndex].m_installationStep = 4; //installation finish on error
+                        return; //exit function now
+                    }
                 }
                 else if(installationScriptAsset.m_download_url.startsWith("/",Qt::CaseInsensitive)) //to check if it's a local repo using path
                 {

--- a/src/backend/model/internal/updates/Updates.cpp
+++ b/src/backend/model/internal/updates/Updates.cpp
@@ -758,7 +758,7 @@ QList <UpdateEntry> Updates::parseJsonComponentFile(QString componentName)
                 m_versions[i].m_assets.append({ asset_entry[QL1("name")].toString(),
                                                 asset_entry[QL1("created_at")].toString(),
                                                 asset_entry[QL1("published_at")].toString(),
-                                                asset_entry[QL1("size")].toInt(),
+                                                qint64(asset_entry[QL1("size")].toDouble()),
                                                 asset_entry[QL1("browser_download_url")].toString()});
                 if(asset_entry[QL1("browser_download_url")].toString().contains("icon.png")){
                     m_versions[i].m_icon = asset_entry[QL1("browser_download_url")].toString();
@@ -766,10 +766,10 @@ QList <UpdateEntry> Updates::parseJsonComponentFile(QString componentName)
                 else if(asset_entry[QL1("browser_download_url")].toString().contains("picture.png")){
                     m_versions[i].m_picture = asset_entry[QL1("browser_download_url")].toString();
                 }
-                Log::info(log_tag, LOGMSG("asset_entry[QL1('name')].toString(): %1").arg(asset_entry[QL1("name")].toString()));
-                Log::info(log_tag, LOGMSG("asset_entry[QL1('size')].toInt(): %1").arg(asset_entry[QL1("size")].toInt()));
-                Log::info(log_tag, LOGMSG("m_versions[i].m_assets.size(): %1").arg(QString::number(m_versions[i].m_assets.size())));
-                m_versions[i].m_size = m_versions[i].m_size + asset_entry[QL1("size")].toInt();
+                //Log::info(log_tag, LOGMSG("asset_entry[QL1('name')].toString(): %1").arg(asset_entry[QL1("name")].toString()));
+                //Log::info(log_tag, LOGMSG("asset_entry[QL1('size')].ToDouble(): %1").arg(QString::number(qint64(asset_entry[QL1("size")].toDouble()))));
+                m_versions[i].m_size = m_versions[i].m_size + qint64(asset_entry[QL1("size")].toDouble());
+                //Log::info(log_tag, LOGMSG("m_versions[i].m_size: %1").arg(QString::number(m_versions[i].m_size)));
             }
             i++;
         }

--- a/src/backend/model/internal/updates/Updates.cpp
+++ b/src/backend/model/internal/updates/Updates.cpp
@@ -323,6 +323,8 @@ bool Updates::hasAnyUpdate(){
 int Updates::hasUpdate(QString componentName, const bool betaIncluded, const bool multiVersions, const QString filter){
     //to avoid issue with directories and scripts
     componentName = cleanName(componentName);
+    //Log::debug(LOGMSG("hasUpdate - componentName : %1").arg(componentName));
+    //Log::debug(LOGMSG("hasUpdate - betaIncluded : %1").arg(betaIncluded ? "true" : "false"));
 
     QList <UpdateEntry> m_versions;
     QString existingVersion;
@@ -353,7 +355,7 @@ int Updates::hasUpdate(QString componentName, const bool betaIncluded, const boo
             //create it
             QDir().mkdir(directoryPath);
         }
-        Log::debug(LOGMSG("versionScriptAsset.m_download_url: %1").arg(versionScriptAsset.m_download_url));
+        //Log::debug(LOGMSG("hasUpdate - versionScriptAsset.m_download_url: %1").arg(versionScriptAsset.m_download_url));
         //In case of multiVersions, finally delete script systematically to avoid problem With a previous one
         if(multiVersions) QFile(directoryPath + "/" + versionScriptAsset.m_name_asset).remove();
         //check if any script version already exists

--- a/src/backend/model/internal/updates/Updates.cpp
+++ b/src/backend/model/internal/updates/Updates.cpp
@@ -561,11 +561,11 @@ void Updates::launchComponentInstallation_slot(QString componentName, const QStr
                 {
                     //first download zip, script and other asset files + clear before to use or reuse the slot
                     downloadManager[m_updates[foundIndex].m_downloaderIndex].clear(); // to reset count of downloaded and total of files.
-                    if (installationScriptAsset.m_name_asset != "") downloadManager[m_updates[foundIndex].m_downloaderIndex].append(QUrl(installationScriptAsset.m_download_url),diretoryPath + "/" + installationScriptAsset.m_name_asset);
-                    if (zipAsset.m_name_asset != "") downloadManager[m_updates[foundIndex].m_downloaderIndex].append(QUrl(zipAsset.m_download_url),diretoryPath + "/" + zipAsset.m_name_asset);
+                    if (installationScriptAsset.m_name_asset != "") downloadManager[m_updates[foundIndex].m_downloaderIndex].append(QUrl(installationScriptAsset.m_download_url),diretoryPath + "/" + installationScriptAsset.m_name_asset); //no set size to always download from 0
+                    if (zipAsset.m_name_asset != "") downloadManager[m_updates[foundIndex].m_downloaderIndex].append(QUrl(zipAsset.m_download_url),diretoryPath + "/" + zipAsset.m_name_asset, zipAsset.m_size);
                     //additional ones only when we ahve to update OS
-                    if (sha1Asset.m_name_asset != "") downloadManager[m_updates[foundIndex].m_downloaderIndex].append(QUrl(sha1Asset.m_download_url),diretoryPath + "/" + sha1Asset.m_name_asset);
-                    if (imgAsset.m_name_asset != "") downloadManager[m_updates[foundIndex].m_downloaderIndex].append(QUrl(imgAsset.m_download_url),diretoryPath + "/" + imgAsset.m_name_asset);
+                    if (sha1Asset.m_name_asset != "") downloadManager[m_updates[foundIndex].m_downloaderIndex].append(QUrl(sha1Asset.m_download_url),diretoryPath + "/" + sha1Asset.m_name_asset); //no set size to always download from 0
+                    if (imgAsset.m_name_asset != "") downloadManager[m_updates[foundIndex].m_downloaderIndex].append(QUrl(imgAsset.m_download_url),diretoryPath + "/" + imgAsset.m_name_asset, imgAsset.m_size);
 
                     //do loop on connect to wait download in this case
                     m_updates[foundIndex].m_installationStep = 1;
@@ -575,7 +575,6 @@ void Updates::launchComponentInstallation_slot(QString componentName, const QStr
                     Log::debug(log_tag, LOGMSG("launchComponentInstallation_slot: %1").arg(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusMessage));
                     if(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusError > 0){
                         Log::debug(log_tag, LOGMSG("launchComponentInstallation_slot: finished with error - exit status: %1").arg(QString::number(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusError)));
-                        this->m_updates[foundIndex].m_installationStep = 4; //installation finish on error
                         return; //exit function now
                     }
                 }
@@ -690,7 +689,7 @@ int Updates::getInstallationError(QString componentName){
     for(int i = 0;i < m_updates.count();i++){
         if(m_updates[i].m_componentName == componentName){
             if(m_updates[i].m_installationStep == 1){
-                return 0; //no error code manage during this step at the moment
+                return downloadManager[m_updates[i].m_downloaderIndex].statusError;
             }
             else if(m_updates[i].m_installationStep >= 2){//if we are installing...and more.
                //return content of file /tmp/componentName/install.err
@@ -767,8 +766,9 @@ QList <UpdateEntry> Updates::parseJsonComponentFile(QString componentName)
                 else if(asset_entry[QL1("browser_download_url")].toString().contains("picture.png")){
                     m_versions[i].m_picture = asset_entry[QL1("browser_download_url")].toString();
                 }
-                //Log::info(log_tag, LOGMSG("asset_entry[QL1('name')].toString(): %1").arg(asset_entry[QL1("name")].toString()));
-                //Log::info(log_tag, LOGMSG("asset_entry[QL1('size')].toString(): %1").arg(asset_entry[QL1("size")].toInt()));
+                Log::info(log_tag, LOGMSG("asset_entry[QL1('name')].toString(): %1").arg(asset_entry[QL1("name")].toString()));
+                Log::info(log_tag, LOGMSG("asset_entry[QL1('size')].toInt(): %1").arg(asset_entry[QL1("size")].toInt()));
+                Log::info(log_tag, LOGMSG("m_versions[i].m_assets.size(): %1").arg(QString::number(m_versions[i].m_assets.size())));
                 m_versions[i].m_size = m_versions[i].m_size + asset_entry[QL1("size")].toInt();
             }
             i++;

--- a/src/backend/model/internal/updates/Updates.h
+++ b/src/backend/model/internal/updates/Updates.h
@@ -17,7 +17,7 @@ struct UpdateAssets {
     QString m_name_asset;
     QString m_created_at_asset;
     QString m_published_at_asset;
-    int m_size;
+    qint64 m_size;
     QString m_download_url;
 };
 Q_DECLARE_METATYPE(UpdateAssets)
@@ -52,7 +52,7 @@ struct UpdateEntry {
       //from asset
       Q_PROPERTY(QString icon MEMBER m_icon)
       Q_PROPERTY(QString picture MEMBER m_picture)
-      Q_PROPERTY(int size MEMBER m_size) //get size of the update, if several files, all sizes will be added to have the full size in this value.
+      Q_PROPERTY(qint64 size MEMBER m_size) //get size of the update, if several files, all sizes will be added to have the full size in this value.
 
 
 
@@ -68,7 +68,7 @@ public:
       //if available from repo
       QString m_icon = "";
       QString m_picture = "";
-      int m_size; //to have the total size
+      qint64 m_size; //to have the total size
 
       //for asset
       QList <UpdateAssets> m_assets;

--- a/src/backend/model/internal/updates/Updates.h
+++ b/src/backend/model/internal/updates/Updates.h
@@ -100,7 +100,7 @@ public:
     //function to get any version details using index
     Q_INVOKABLE UpdateEntry componentVersionDetails(QString componentName, const int versionIndex);
     //Asynchronous function to install a component
-    Q_INVOKABLE void launchComponentInstallation(QString componentName, const QString version);
+    Q_INVOKABLE void launchComponentInstallation(QString componentName, const QString version, const QString downloaddirectory = "");
     //Function to know status - as "Download", "Installation", "Completed" or "error"
     Q_INVOKABLE QString getInstallationStatus(QString componentName);
     //Fucntion to know progress of each installation steps
@@ -117,7 +117,7 @@ private slots:
     //to have thread to download JSON file from repo
     void getRepoInfo_slot(QString componentName, QString repoUrl);
     //to have thread to download ZIP file/Script and to install the new component
-    void launchComponentInstallation_slot(QString componentName, const QString version);
+    void launchComponentInstallation_slot(QString componentName, const QString version, const QString downloaddirectory);
 
 public:
 

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1199,6 +1199,42 @@ Window {
             //start other timers
             repoStatusRefreshTimer.start();
             updatePopupTimer.start();
+            checkUpgradeTimer.start();
+
+        }
+    }
+
+    Timer{//timer to check and alert about upgrade
+        id: checkUpgradeTimer
+        interval: 5000 // Check after 5 s
+        repeat: false //check and display popup only one time
+        running: false
+        triggeredOnStart: false
+        onTriggered: {
+            var upgradeFailed = api.internal.system.run("test -f /tmp/upgradefailed && echo 'true' || echo 'false'").includes("true") ? true : false
+            var upgraded = api.internal.system.run("test -f /tmp/upgraded && echo 'true' || echo 'false'").includes("true") ? true : false
+            //check if upgraded or failed
+            if((upgradeFailed === true) || (upgraded === true)){
+                //to popup to alert about upgrade
+                //init parameters
+                popup.title = qsTr("Information");
+                if(upgradeFailed === true){
+                    popup.message = qsTr("Upgrade failed !");
+                }
+                else if(upgraded === true){
+                    popup.message = qsTr("Upgrade done !");
+                }
+                //icon is optional but should be set to empty string if not use
+                popup.icon = "\uf2c6";
+                popup.iconfont = global.fonts.ion;
+                //delay provided in second and interval is in ms
+                popupDelay.interval = 10 * 1000;
+                //Open popup and set it as showable to have animation
+                popup.open();
+                popup.showing = true;
+                //start timer to close popup automatically
+                popupDelay.restart();
+            }
         }
     }
 

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1191,7 +1191,13 @@ Window {
                     }
                 }
                 else{// for dev testing only about updates
-                    componentsListModel.append({ componentName: "pixL-OS (Dev)", repoUrl:"https://updates.pixl-os.com/dev-pixl-os.json",icon: "qrc:/frontend/assets/logobeta.png", picture: "qrc:/frontend/assets/backgroundpixl.png", multiVersions: false});
+                    //check that 'dev' updates is not selected
+                    if(api.internal.recalbox.getStringParameter("updates.format") !== "raw"){
+                        componentsListModel.append({ componentName: "pixL-OS (Dev)", repoUrl:"https://updates.pixl-os.com/dev-pixl-os.json",icon: "qrc:/frontend/assets/logobeta.png", picture: "qrc:/frontend/assets/backgroundpixl.png", multiVersions: false, downloaddirectory: "/recalbox/share/system/upgrade"});
+                    }
+                    else {
+                        componentsListModel.append({ componentName: "pixL-OS (Dev)", repoUrl:"https://updates.pixl-os.com/dev-raw-pixl-os.json",icon: "qrc:/frontend/assets/logobeta.png", picture: "qrc:/frontend/assets/backgroundpixl.png", multiVersions: false, downloaddirectory: "/boot/update"});
+                    }
                 }
             }
             //stop timer

--- a/src/frontend/menu/settings/UpdatesMain.qml
+++ b/src/frontend/menu/settings/UpdatesMain.qml
@@ -60,7 +60,7 @@ FocusScope {
             switch (actionState) {
                     case "Update": //-> TO UPDATE
                         //launch process of udpate (including download and installation)
-                        api.internal.updates.launchComponentInstallation(componentsListModel.get(actionListIndex).componentName,componentsListModel.get(actionListIndex).versionToInstall);
+                        api.internal.updates.launchComponentInstallation(componentsListModel.get(actionListIndex).componentName,componentsListModel.get(actionListIndex).versionToInstall, (typeof(componentsListModel.get(actionListIndex).downloaddirectory) !== "undefined") ? componentsListModel.get(actionListIndex).downloaddirectory : "");
                         break;
             }
             confirmDialog.active = false;

--- a/src/frontend/menu/settings/UpdatesMain.qml
+++ b/src/frontend/menu/settings/UpdatesMain.qml
@@ -243,6 +243,7 @@ FocusScope {
                             if(entry !== null){
                                 // calculate unit of size
                                 var size = entry.size;
+                                console.log("size in bytes: ", size)
                                 let unit;
                                 if (size < 1024) {
                                     unit = qsTr("bytes") + api.tr;

--- a/src/frontend/menu/settings/UpdatesMain.qml
+++ b/src/frontend/menu/settings/UpdatesMain.qml
@@ -203,6 +203,11 @@ FocusScope {
                             console.log("item.hasUpdate : ", item.hasUpdate);
                             if(typeof(item.hasUpdate) !== "undefined"){
                                 if(item.hasUpdate === true){
+                                    //to force update of info at initialization
+                                    progressStatus = api.internal.updates.getInstallationStatus(item.componentName);
+                                    progress = api.internal.updates.getInstallationProgress(item.componentName);
+                                    errorCode = api.internal.updates.getInstallationError(item.componentName);
+
                                     if(api.internal.updates.getInstallationProgress(item.componentName) !== 1.0 ||
                                        api.internal.updates.getInstallationError(item.componentName) !== 0){
                                         return api.internal.updates.updateDetails(item.componentName,item.UpdateVersionIndex);


### PR DESCRIPTION
	- pixL upgrade/update improvements:
	    - in scriptmanager, add dedicated thread to execute script as install.sh and without UI blocking
	    - use "shutdown -r now" command to do a full reboot now
	    - change to well display status immediately when we load Updates view
	    - add popup at start when full upgrade is done or failed
	    - add management to resume download if file already exists in download directory
	    - fix display using 'long qint64' and not just 'int' for assets size
	    - add feature to be able to change download directory for update including size & raw format management
	    - not count file not well downloaded now (to detect better issues)
	    - add feature to be able to test updates from personal repo for dev purposes (using updates.devuser parameter)