### PR TITLE
new improvments to manage update for libretro/standalone mame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file (focus on change done on recalbox-integration branch).
 
-## [pixL-master] - 2024-mm-dd - v0.1.x
+## [pixL-master] - 2024-07-07 - v0.1.7
 - Fixes:
 	- fix ip display in settings menu
 	- reduce size of navigation.wav file sound effect to win in velocity during scrollling of sound bar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file (focus on ch
 	    - not count file not well downloaded now (to detect better issues)
 	    - add feature to be able to test updates from personal repo for dev purposes (using updates.devuser parameter)
 	- add Cemu update online
+    - add Standalone Mame online update (mamedev-mame) + Change repo naming for libretro mame (libretro-mame) (should be change in pixL repo after pixL Beta 36 deployement)
 
 ## [pixL-master] - 2024-03-05 - v0.1.6
 - Features:

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1146,8 +1146,9 @@ Window {
     ListModel {
         id: componentsListModel
         ListElement { componentName: "Pegasus-frontend"; repoUrl:"https://api.github.com/repos/pixl-os/pegasus-frontend/releases";icon: "qrc:/frontend/assets/logopegasus.png"; picture: ""; multiVersions: false}
+        ListElement { componentName: "Mame"; repoUrl:"https://api.github.com/repos/pixl-os/mamedev-mame/releases";icon:""; picture: ""; multiVersions: false}
+        ListElement { componentName: "Libretro Mame"; repoUrl:"https://api.github.com/repos/pixl-os/libretro-mame/releases";icon:""; picture: ""; multiVersions: false}
         ListElement { componentName: "Libretro FBNeo"; repoUrl:"https://api.github.com/repos/pixl-os/FBNeo/releases";icon:""; picture: ""; multiVersions: false}
-        ListElement { componentName: "Libretro Mame"; repoUrl:"https://api.github.com/repos/pixl-os/mame/releases";icon:""; picture: ""; multiVersions: false}
         ListElement { componentName: "Xemu"; repoUrl:"https://api.github.com/repos/pixl-os/xemu/releases";icon:""; picture: ""; multiVersions: false}
         ListElement { componentName: "Cemu"; repoUrl:"https://api.github.com/repos/pixl-os/cemu/releases";icon:""; picture: ""; multiVersions: false}
         ListElement { componentName: "Supermodel"; repoUrl:"https://api.github.com/repos/pixl-os/Supermodel/releases";icon:""; picture: ""; multiVersions: false}

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1204,7 +1204,8 @@ Window {
                             if((typeof(componentsListModel.get(i).repoUrl) !== "undefined") && (componentsListModel.get(i).repoUrl !== ""))
                             {
                                 //console.log("component created for dev purpose : ", componentsListModel.get(i).componentName + " (Dev)")
-                                componentsListModel.append({ componentName: componentsListModel.get(i).componentName + " (Dev)", repoUrl: componentsListModel.get(i).repoUrl.replace("pixl-os", api.internal.recalbox.getStringParameter("updates.devuser")) ,icon: componentsListModel.get(i).icon, picture: componentsListModel.get(i).picture, multiVersions: componentsListModel.get(i).multiVersions});
+                                componentsListModel.get(i).componentName = componentsListModel.get(i).componentName + " (Dev)"
+                                componentsListModel.get(i).repoUrl = componentsListModel.get(i).repoUrl.replace("pixl-os", api.internal.recalbox.getStringParameter("updates.devuser"))
                             }
                             else if((typeof(componentsListModel.get(i).repoLocal) !== "undefined") && (componentsListModel.get(i).repoLocal !== ""))
                             {


### PR DESCRIPTION
 add Standalone Mame online update (mamedev-mame) + Change repo naming for libretro mame (libretro-mame) (should be change in pixL repo after pixL Beta 36 deployement)
