### PR TITLE
fixes from Beta 1.37 (pegasus-fe v0.1.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable changes to this project will be documented in this file (focus on ch
 	- fix on save of value using previous values in some cases
 	- find the best compromising for popup resize depending of content
 	- add deadzone for pegasus + manage better sign detection during configuration of controllers
+	- add more checks and exceptions management to avoid crash at start during parsing of information about partitions
 
 ## [pixL-master] - 2024-07-07 - v0.1.7
 - Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ All notable changes to this project will be documented in this file (focus on ch
 	- find the best compromising for popup resize depending of content
 	- add deadzone for pegasus + manage better sign detection during configuration of controllers
 	- add more checks and exceptions management to avoid crash at start during parsing of information about partitions
+	- move pegasus-frontend window to well reasign current applications on primary screen when it's needed
+	- fix video mode internalvalue not well set in some times
 
 ## [pixL-master] - 2024-07-07 - v0.1.7
 - Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ All notable changes to this project will be documented in this file (focus on ch
 	- fix rcheevos to have "Gamecube" in iso format for RA (https://github.com/RetroAchievements/rcheevos/pull/353)
 	- add tmp files generation if missing to improve performance
 	- set as INTERNAL value for Internal SHARE
+	- fix on save of value for system.video.screens.mode
+	- fix on save of value using previous values in some cases
+	- find the best compromising for popup resize depending of content
+	- add deadzone for pegasus + manage better sign detection during configuration of controllers
 
 ## [pixL-master] - 2024-07-07 - v0.1.7
 - Fixes:

--- a/src/backend/model/internal/GamepadManagerSDL2.h
+++ b/src/backend/model/internal/GamepadManagerSDL2.h
@@ -71,6 +71,7 @@ private:
 		std::string target_sign = "";
         std::string value;
         std::string sign;
+        Sint16 previous_axis_value = 0; //to be reset to 0 at each recording
 
         bool is_active() const;
         void reset();

--- a/src/backend/model/internal/System.cpp
+++ b/src/backend/model/internal/System.cpp
@@ -17,6 +17,7 @@
 
 #include "System.h"
 #include <QProcess>
+#include "Log.h"
 
 
 namespace model {
@@ -92,6 +93,7 @@ bool System::runBoolResult(const QString& Command, bool escaped)
       Strings::ReplaceAllIn(escapedCommand, "'", "\\'");
       Strings::ReplaceAllIn(escapedCommand, "\"", "\\\"");
   }
+  //Log::debug(LOGMSG("runBoolResult escaped Command : '%1'").arg(escapedCommand.c_str()));
   int exitcode = system(escapedCommand.c_str());
   return exitcode == 0;
 }

--- a/src/backend/storage/StorageDevices.cpp
+++ b/src/backend/storage/StorageDevices.cpp
@@ -31,14 +31,14 @@ void StorageDevices::Initialize()
   String propertyLine;
   long long Size;          //!< Size in byte
 
-  { LOG(LogDebug) << "[Storage] AnalyseMounts() function to launch"; }
+  //{ LOG(LogDebug) << "[Storage] AnalyseMounts() function to launch"; }
   AnalyseMounts();
-  { LOG(LogDebug) << "[Storage] GetStorageDevice() function to launch"; }
+  //{ LOG(LogDebug) << "[Storage] GetStorageDevice() function to launch"; }
   String current = GetStorageDevice();
   // Get storage sizes
-  { LOG(LogDebug) << "[Storage] GetFileSystemInfo() function to launch"; }
+  //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo() function to launch"; }
   DeviceSizeInfo sizeInfos = GetFileSystemInfo();
-  { LOG(LogDebug) << "[Storage] GetFileSystemInfo() done"; }
+  //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo() done"; }
 
   // Ram?
   if (mShareInRAM)
@@ -83,7 +83,7 @@ void StorageDevices::Initialize()
       else{
         mDevices.push_back(Device(Types::Internal, devicePath, uuid, label, filesystem, displayable, false, sizeInfos));
       }
-      { LOG(LogDebug) << "[Storage] Internal Share partition: " << devicePath << ' ' << uuid << " \"" << label << "\" " << filesystem << " size (bytes): " << Size; }
+      //{ LOG(LogDebug) << "[Storage] Internal Share partition: " << devicePath << ' ' << uuid << " \"" << label << "\" " << filesystem << " size (bytes): " << Size; }
   }
   else{
       //if issue to detect SHARE
@@ -94,22 +94,22 @@ void StorageDevices::Initialize()
   if (mBootConfiguration.HasKeyStartingWith("sharenetwork_") || mBootConfiguration.AsString("sharedevice") == "NETWORK")
   {
     mDevices.push_back(Device(Types::Internal, "", sNetwork, "", "", _("\uf086  Network Share"), current == sNetwork, sizeInfos));
-    { LOG(LogDebug) << "[Storage] Network share configuration detected"; }
+    //{ LOG(LogDebug) << "[Storage] Network share configuration detected"; }
   }
 
   // Any external
   if (mBootConfiguration.AsString("sharedevice") == "ANYEXTERNAL") {
       mDevices.push_back(Device(Types::Internal, "",  sAnyExternal, "", "",_("Any External Device").append(_(" (Deprecated)")), current == sAnyExternal, sizeInfos));
-    { LOG(LogDebug) << "[Storage] Any external share configuration detected"; }
+    //{ LOG(LogDebug) << "[Storage] Any external share configuration detected"; }
   }
 
   // External Devices
   for(const String& line : GetRawDeviceList()){
-    { LOG(LogDebug) << "[Storage] GetRawDeviceList line: " << line; }
+    //{ LOG(LogDebug) << "[Storage] GetRawDeviceList line: " << line; }
     if (line.Extract(':', devicePath, propertyLine, true))
     {
-      { LOG(LogDebug) << "[Storage] propertyLine: " << propertyLine; }
-      { LOG(LogDebug) << "[Storage] devicePath: " << devicePath; }
+      //{ LOG(LogDebug) << "[Storage] propertyLine: " << propertyLine; }
+      //{ LOG(LogDebug) << "[Storage] devicePath: " << devicePath; }
 
       // Avoid boot device partitions
       if (devicePath.StartsWith(mBootRoot)) continue;
@@ -146,7 +146,7 @@ void StorageDevices::Initialize()
 
       // Store
       mDevices.push_back(Device(Types::External, devicePath, uuid, label, filesystem, displayable, current == uuid, sizeInfos));
-      { LOG(LogDebug) << "[Storage] External partition: " << devicePath << ' ' << uuid << " \"" << label << "\" " << filesystem << " size (bytes): " << Size; }
+      //{ LOG(LogDebug) << "[Storage] External partition: " << devicePath << ' ' << uuid << " \"" << label << "\" " << filesystem << " size (bytes): " << Size; }
     }
   }
 }
@@ -245,21 +245,21 @@ StorageDevices::DeviceSizeInfo StorageDevices::GetFileSystemInfo()
     DeviceSizeInfo result;
     try{
         //potential crash if problem during parsing
-        { LOG(LogDebug) << "[Storage] GetFileSystemInfo() function launched !"; }
+        //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo() function launched !"; }
         //if tmp file doesn't exists, we have to create it
-        { LOG(LogDebug) << "[Storage] GetFileSystemInfo() step 1"; }
+        //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo() step 1"; }
         if(!QFile::exists("/tmp/df-kP")) GetCommandOutput("df -kP > /tmp/df-kP");
-        { LOG(LogDebug) << "[Storage] GetFileSystemInfo() step 2"; }
+        //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo() step 2"; }
         for(const String& line : GetCommandOutput("cat /tmp/df-kP"))
         {
-            { LOG(LogDebug) << "[Storage] GetFileSystemInfo() step 3"; }
+            //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo() step 3"; }
             String::List items = line.Split(' ', true);
-            { LOG(LogDebug) << "[Storage] GetFileSystemInfo items.size(): " << items.size() ; }
+            //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo items.size(): " << items.size() ; }
             if (items.size() >= 6)
             {
-              { LOG(LogDebug) << "[Storage] GetFileSystemInfo line (df -kP): " << line ; }
-              { LOG(LogDebug) << "[Storage] GetFileSystemInfo items[1]: " << items[1] ; }
-              { LOG(LogDebug) << "[Storage] GetFileSystemInfo items[3]: " << items[3] ; }
+              //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo line (df -kP): " << line ; }
+              //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo items[1]: " << items[1] ; }
+              //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo items[3]: " << items[3] ; }
               long long size = items[1].AsInt64();
               long long free = items[3].AsInt64();
               result[items[0]] = SizeInfo(size, free);
@@ -278,16 +278,16 @@ StorageDevices::DeviceSizeInfo StorageDevices::GetFileSystemInfo()
         for(const String& line : GetCommandOutput("cat /tmp/fdisk-list"))
         {
           String::List items = line.Split(' ', true);
-          { LOG(LogDebug) << "[Storage] GetFileSystemInfo items size: " << items.size() ; }
+          //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo items size: " << items.size() ; }
             if(items.size() >= 1){ //at minimum, we need 2 items per line to manage it during this parsing and avoid crash
               if(items[0] == "Number"){
-                  { LOG(LogDebug) << "[Storage] GetFileSystemInfo line (fdisk -l) Number: " << line ; }
+                  //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo line (fdisk -l) Number: " << line ; }
                   isDisk = true;
                   isDevice = false;
                   continue;
               }
               if(items[0] == "Device"){
-                  { LOG(LogDebug) << "[Storage] GetFileSystemInfo line (fdisk -l) Device: " << line ; }
+                  //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo line (fdisk -l) Device: " << line ; }
                   currentDisk="";
                   isDisk = false;
                   isDevice = true;
@@ -296,18 +296,18 @@ StorageDevices::DeviceSizeInfo StorageDevices::GetFileSystemInfo()
             }
             if(items.size() >= 2){ //at minimum, we need 2 items per line to manage it during this parsing and avoid crash
               if((items[0] == "Disk") && items[1].StartsWith("/dev/")){
-                  { LOG(LogDebug) << "[Storage] GetFileSystemInfo line (fdisk -l) Disk: " << line ; }
+                  //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo line (fdisk -l) Disk: " << line ; }
                   currentDisk = items[1].Replace(":","");
                   isDisk = false;
                   isDevice = false;
                   continue;
               }
               if((isDisk and isNumeric(items[1])) || (items[0].StartsWith("/dev/") and isDevice)){
-                  { LOG(LogDebug) << "[Storage] GetFileSystemInfo line (fdisk -l) isDisk or isDevice: " << line ; }
+                  //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo line (fdisk -l) isDisk or isDevice: " << line ; }
                   String partition = "";
                   int sizeIndex = 0;
                   if(isDisk){
-                      { LOG(LogDebug) << "[Storage] GetFileSystemInfo items[1] : " << items[1] ; }
+                      //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo items[1] : " << items[1] ; }
                       partition = currentDisk + "p" + items[1];
                       sizeIndex = 4;
                   }
@@ -318,16 +318,16 @@ StorageDevices::DeviceSizeInfo StorageDevices::GetFileSystemInfo()
                           sizeIndex = sizeIndex + 1;
                       }
                   }
-                  { LOG(LogDebug) << "[Storage] GetFileSystemInfo partition : " << partition ; }
+                  //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo partition : " << partition ; }
                   //check if not already knwon/mount
                   SizeInfo* info = result.try_get(partition);
                   if ((info == nullptr) && (int(items.size()) > sizeIndex)) //check size of items to avoid crash
                   {
-                      { LOG(LogDebug) << "[Storage] GetFileSystemInfo items[sizeIndex] : " << items[sizeIndex] ; }
+                      //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo items[sizeIndex] : " << items[sizeIndex] ; }
                       char lastChar = items[sizeIndex].back();
                       String numeric = items[sizeIndex].SubString(0,items[sizeIndex].length()-1); //just remove last char
-                      { LOG(LogDebug) << "[Storage] GetFileSystemInfo lastChar : " << lastChar ; }
-                      { LOG(LogDebug) << "[Storage] GetFileSystemInfo numeric : " << numeric ; }
+                      //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo lastChar : " << lastChar ; }
+                      //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo numeric : " << numeric ; }
                       numeric = numeric.Split('.', true).at(0); // to keep only first part before . in all cases
                       long long size = 0;
                       switch (lastChar) {
@@ -348,9 +348,9 @@ StorageDevices::DeviceSizeInfo StorageDevices::GetFileSystemInfo()
                           break;
                       }
                       long long free = -1; // unknown in this case
-                      { LOG(LogDebug) << "[Storage] GetFileSystemInfo size : " << size ; }
+                      //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo size : " << size ; }
                       result[partition] = SizeInfo(size, free);
-                      { LOG(LogDebug) << "[Storage] GetFileSystemInfo result[partition] completed"; }
+                      //{ LOG(LogDebug) << "[Storage] GetFileSystemInfo result[partition] completed"; }
                   }
               }
               else if((isDisk and !isNumeric(items[1])) || (!items[0].StartsWith("/dev/") and isDevice)){
@@ -397,8 +397,8 @@ void StorageDevices::SetStorageDevice(const StorageDevices::Device& device)
 
 String StorageDevices::GetStorageDevice()
 {
-  { LOG(LogDebug) << "[Storage] GetStorageDevice() function launched !"; }
-  { LOG(LogDebug) << "[Storage] GetStorageDevice() - sShareDevice: " << sShareDevice << " , sInternal: " << sInternal; }
+  //{ LOG(LogDebug) << "[Storage] GetStorageDevice() function launched !"; }
+  //{ LOG(LogDebug) << "[Storage] GetStorageDevice() - sShareDevice: " << sShareDevice << " , sInternal: " << sInternal; }
   return mBootConfiguration.AsString(sShareDevice, sInternal);
 }
 
@@ -417,6 +417,6 @@ void StorageDevices::AnalyseMounts()
     else if (items[2] == "/boot") mBootRoot = items[0].Trim("0123456789");
   }
   if (mBootRoot.empty()) mBootRoot = "/dev/boot"; // for testing purpose only :)
-  { LOG(LogDebug) << "[Storage] BootRoot: " << mBootRoot << " - Is In Ram: " << mShareInRAM; }
+  //{ LOG(LogDebug) << "[Storage] BootRoot: " << mBootRoot << " - Is In Ram: " << mShareInRAM; }
 }
 

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1377,7 +1377,7 @@ Window {
 
         property alias iconfont: iconText.font.family
 
-        width:  (message.length > title.length) ? vpx(message.length * 7.5 + ((icon.length !== 0) ? 50 : 0)) + popup.titleTextSize : vpx(title.length * 7.5 + ((icon.length !== 0) ? 50 : 0) + popup.titleTextSize) //vpx(200)
+        width: (messageText.text.length > titleText.text.length ? messageText.text.length * vpx(5) : titleText.text.length * vpx(7.5)) + ((icon.length !== 0) ? iconSize : vpx(20)) + vpx(15)
         height: vpx(70)
 
         background: Rectangle {
@@ -1426,10 +1426,7 @@ Window {
                         top: parent.top
                         left: parent.left
                         right:  parent.right;
-                        leftMargin: popup.titleTextSize * 0.5
-                        rightMargin: popup.titleTextSize * 0.5
                     }
-                    width: parent.width - (2 * anchors.leftMargin)
                     height: popup.titleTextSize * 1.2
                     color: themeColor.textTitle
                     fontSizeMode: Text.Fit
@@ -1448,7 +1445,8 @@ Window {
                         top: titleText.bottom
                         bottom: parent.bottom
                         right:  parent.right;
-                        rightMargin: popup.titleTextSize * 0.1
+                        rightMargin: vpx(5)
+                        bottomMargin: vpx(5)
                     }
                     width: height
                     color: themeColor.textTitle
@@ -1472,10 +1470,9 @@ Window {
                         bottom: parent.bottom
                         left: parent.left
                         right: (popup.icon !== "") ? iconText.left : parent.right
-                        leftMargin: popup.titleTextSize * 0.5
-                        rightMargin: popup.titleTextSize * 0.5
+                        rightMargin: vpx(3)
+                        bottomMargin: vpx(2)
                     }
-                    width: parent.width - (2 * anchors.leftMargin)
                     verticalAlignment: Text.AlignVCenter
                     color: themeColor.textLabel
                     fontSizeMode: Text.Fit

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -92,6 +92,7 @@ FocusScope {
                     note: qsTr("Choose any mode to manage behavior when you plug/unplug any screen") + api.tr
 
                     value: api.internal.recalbox.parameterslist.currentName(parameterName)
+                    internalvalue: api.internal.recalbox.parameterslist.currentInternalName(parameterName)
 
                     currentIndex: api.internal.recalbox.parameterslist.currentIndex;
                     count: api.internal.recalbox.parameterslist.count;
@@ -816,9 +817,10 @@ FocusScope {
                     }
                     onActivate: {
                         //for display mode
-                        api.internal.recalbox.setStringParameter(optDisplayMode.parameterName,optDisplayMode.internalvalue);
+                        //console.log("optDisplayMode.parameterName: ", optDisplayMode.parameterName, "optDisplayMode.internalvalue: ", optDisplayMode.internalvalue)
+                        api.internal.recalbox.setStringParameter(optDisplayMode.parameterName, optDisplayMode.internalvalue);
                         //for first screen (if activated)
-                        api.internal.recalbox.setBoolParameter(optPrimaryScreenActivate.parameterName,optPrimaryScreenActivate.checked);
+                        api.internal.recalbox.setBoolParameter(optPrimaryScreenActivate.parameterName, optPrimaryScreenActivate.checked);
                         if(optPrimaryScreenActivate.checked){
                             api.internal.recalbox.setStringParameter(optDisplayOutput.parameterName, optDisplayOutput.value)
                             api.internal.recalbox.setStringParameter(optDisplayResolution.parameterName, optDisplayResolution.value)
@@ -880,6 +882,7 @@ FocusScope {
             //for display mode
             optDisplayMode.previousvalue = optDisplayMode.value
             optDisplayMode.previousinternalvalue = api.internal.recalbox.getStringParameter(optDisplayMode.parameterName)
+            //console.log("optDisplayMode.previousvalue: ", optDisplayMode.previousvalue, "optDisplayMode.previousinternalvalue: ", optDisplayMode.previousinternalvalue)
             //for first screen (if activated)
             optPrimaryScreenActivate.previousvalue = optPrimaryScreenActivate.checked
             if(optPrimaryScreenActivate.checked){

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -816,7 +816,7 @@ FocusScope {
                     }
                     onActivate: {
                         //for display mode
-                        api.internal.recalbox.setBoolParameter(optDisplayMode.parameterName,optDisplayMode.internalvalue);
+                        api.internal.recalbox.setStringParameter(optDisplayMode.parameterName,optDisplayMode.internalvalue);
                         //for first screen (if activated)
                         api.internal.recalbox.setBoolParameter(optPrimaryScreenActivate.parameterName,optPrimaryScreenActivate.checked);
                         if(optPrimaryScreenActivate.checked){

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -903,7 +903,7 @@ FocusScope {
         function onCancel() {
             //restore previous value
             //for display mode
-            api.internal.recalbox.setStringParameter(optDisplayMode.parameterName,optDisplayMode.previousvalue);
+            api.internal.recalbox.setStringParameter(optDisplayMode.parameterName,optDisplayMode.previousinternalvalue);
             optDisplayMode.value = optDisplayMode.previousvalue;
             //for first screen (if activated)
             api.internal.recalbox.setBoolParameter(optPrimaryScreenActivate.parameterName,optPrimaryScreenActivate.previousvalue);
@@ -924,7 +924,7 @@ FocusScope {
             optDisplaySecondaryOutput.value = optDisplaySecondaryOutput.previousvalue;
             api.internal.recalbox.setStringParameter(optDisplaySecondaryResolution.parameterName, optDisplaySecondaryResolution.previousvalue);
             optDisplaySecondaryResolution.value = optDisplaySecondaryResolution.previousvalue;
-            api.internal.recalbox.setStringParameter(optDisplaySecondaryFrequency.parameterName, optDisplaySecondaryFrequency.previous);
+            api.internal.recalbox.setStringParameter(optDisplaySecondaryFrequency.parameterName, optDisplaySecondaryFrequency.previousvalue);
             optDisplaySecondaryFrequency.value = optDisplaySecondaryFrequency.previousvalue;
             api.internal.recalbox.setStringParameter(optDisplaySecondaryRotation.parameterName, optDisplaySecondaryRotation.previousinternalvalue);
             optDisplaySecondaryRotation.value = optDisplaySecondaryRotation.previousvalue;

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -838,6 +838,8 @@ FocusScope {
                         api.internal.recalbox.saveParameters();
                         //Execute script to udpate screen settings in real-time
                         api.internal.system.runBoolResult("/usr/bin/externalscreen.sh");
+                        //and move pegasus-frontend in connected and primary screen
+                        api.internal.system.runBoolResult("WINDOWPID=$(xdotool search --class 'pegasus-frontend'); xdotool windowmove $WINDOWPID $(xrandr | grep -e ' connected' | grep -e 'primary' | awk '{print $4}' | awk -F'+' '{print $2, $3}');", false);
 
                         //to confirm change or not
                         confirmDialog.focus = false;
@@ -935,6 +937,8 @@ FocusScope {
             api.internal.recalbox.saveParameters();
             //Execute script to restore screen openVideoSettings
             api.internal.system.runBoolResult("/usr/bin/externalscreen.sh");
+            //and move pegasus-frontend in connected and primary screen
+            api.internal.system.runBoolResult("WINDOWPID=$(xdotool search --class 'pegasus-frontend'); xdotool windowmove $WINDOWPID $(xrandr | grep -e ' connected' | grep -e 'primary' | awk '{print $4}' | awk -F'+' '{print $2, $3}');", false);
             content.focus = true;
         }
     }


### PR DESCRIPTION
	- fix on save of value for system.video.screens.mode
	- fix on save of value using previous values in some cases
	- find the best compromising for popup resize depending of content
	- add deadzone for pegasus + manage better sign detection during configuration of controllers
	- add more checks and exceptions management to avoid crash at start during parsing of information about partitions
