### PR TITLE
Second screens (for cemu/citra), virtual and remote display (in browser) - Beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,30 @@ All notable changes to this project will be documented in this file (focus on ch
 	- add Nintendo wiimote controller layout
 	- add auto change disc option in menu advanced settings emulator for dolphin
 	- add crt colors, upscale mode and supersampling options in menu advanced settings emulator for supermodel
-	- add new options in menu advanced settings emulator for RCPS3 as Resolution Scale, Output Scaling Mode, 
-	CurrentStylesheet (themes setting emulator), VSync, UPNP, Network Statut, RPCN Statut, Username, Password and Token
+	- add new options in menu advanced settings emulator for RCPS3 as: 
+		- Resolution Scale, Output Scaling Mode, CurrentStylesheet (themes setting emulator)
+		- VSync, UPNP, Network Statut, RPCN Statut, Username, Password and Token
 	- add capacity to have a multi-usage of same stick as DPAD/LSTICK/RSTICK in 8bitdo arcade stick
-
+	- "Second Screen" in game features (Beta):
+		- add parameter to select virtual screen(s)
+		- add script called after configuration change to prepare conf before reboot
+		- alert for more than one virtual screen
+		- finalize parameters to manage layout/second display
+		- add menu for remote display and weylus service (re)start
+		- add "(Beta)" annotations for some advanced features for the moment 
+		- For cemu:
+			- add parameters to manage wii u gamepad display
+			- add advanced parameter to manage mapping using SDL Button labels
+			- add rumble power to manage rumble for controllers compatible
+			- add rumble simulation from menu using a script
+		- For Citra:
+			- add parameters to manage 3ds bottom screen display
+			- finalize parameters to manage layout/second display
 - Fixes:
 	- fix brightness/contrast during dpad rotations
 	- fix to navigate between left/right x/y axis in gamepad editor
+	- fix to change theme loading way
+	- fix to update "previous value" after each changes/saves in video settings
 
 ## [pixL-master] - 2024-12-02 - v0.1.8.3
 - Quick fixes:

--- a/src/backend/model/internal/settings/ParametersList.cpp
+++ b/src/backend/model/internal/settings/ParametersList.cpp
@@ -543,6 +543,14 @@ QStringList GetParametersList(QString Parameter)
         ListOfInternalValue << "0" << "1" << "2"
                             << "3" << "4" << "5";
     }
+    else if(Parameter == "citra.screens.layout")
+    {
+        ListOfValue << QObject::tr("Default") << QObject::tr("Single Screen") << QObject::tr("Large Screen")
+                    << QObject::tr("Hybrid Screen") << QObject::tr("Side by Side") << QObject::tr("Separated Windows");
+        ListOfInternalValue << "0" << "1" << "2"
+                            << "5" << "3" << "4";
+
+    }
     else if (Parameter.startsWith("cemu.", Qt::CaseInsensitive) == true)
     {
         if (Parameter.endsWith(".filter", Qt::CaseInsensitive) == true)

--- a/src/backend/model/internal/settings/ParametersList.h
+++ b/src/backend/model/internal/settings/ParametersList.h
@@ -40,7 +40,7 @@ public:
     Q_INVOKABLE  QString currentName (const QString& Parameter, const QString& InternalName = "");
     Q_INVOKABLE  QString currentInternalName (const QString& Parameter);
     //CurrentNameFromSystem is used to initiate the parameters list generated from a system/script command and return the existing value from recalbox.conf if exist
-    Q_INVOKABLE  QString currentNameFromSystem (const QString& Parameter, const QString& SysCommand, const QStringList& SysOptions);
+    Q_INVOKABLE  QString currentNameFromSystem (const QString& Parameter, const QString& SysCommand, const QStringList& SysOptions = {});
 
     //CurrentNameChecked to return string with number of checked values/total
     Q_INVOKABLE  QString currentNameChecked (const QString& Parameter);

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1328,15 +1328,28 @@ Window {
         focus: true
         enabled: false
         visible: focus
-
+        z: 10
         property bool dataLoading: api.internal.meta.loading
         property bool skinLoading: theme.status === Loader.Null || theme.status === Loader.Loading
         showDataProgressText: dataLoading
 
         function hideMaybe() {
+            console.log("Splashcreen hiding by focus/z level");
             if (focus && !dataLoading && !skinLoading) {
+                //focus on theme content
                 content.focus = true;
+                //put splashscreen behind
+                z = -1
+                //remove focus from splashcreen
+                focus = false;
+                //reset splashscreen loading bar
                 api.internal.meta.resetLoadingState();
+            }
+            else if (focus){
+                //set in front
+                z = 10;
+                //remove focus from theme content
+                content.focus = false;
             }
         }
         onSkinLoadingChanged: hideMaybe()

--- a/src/frontend/menu/settings/SettingsMain.qml
+++ b/src/frontend/menu/settings/SettingsMain.qml
@@ -325,13 +325,14 @@ FocusScope {
                     pointerIcon: true
 
                     onActivate: {
+                        //line after could be deactivated for testing to test with a specifix xrandr.tmp file not updated
                         api.internal.system.run("/usr/bin/xrandr > /tmp/xrandr.tmp");
                         focus = true;
                         root.openVideoSettings();
                     }
                     onFocusChanged: container.onFocus(this)
                     //                    KeyNavigation.up: optBiosChecking
-                    KeyNavigation.down: optBrightness.visible ? optBrightness : optVideoFiltrer
+                    KeyNavigation.down: (optBrightness.visible || isDebugEnv()) ? optBrightness : optVideoFiltrer
                 }
                 SliderOption {
                     id: optBrightness

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -867,7 +867,7 @@ FocusScope {
 
                     //Remote display settings
                     SectionTitle {
-                        text: qsTr("Remote display settings") + api.tr
+                        text: qsTr("Remote display settings (Beta)") + api.tr
                         first: true
                     }
 

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -169,6 +169,11 @@ FocusScope {
                             //need to reboot (or restart Xorg if possible in the future)
                             console.log("Need reboot");
                             needReboot = true;
+                            //write configuration file for virtual screens
+                            //save conf
+                            api.internal.recalbox.saveParameters();
+                            //Execute script to configure X11 conf
+                            api.internal.system.runBoolResult("/recalbox/scripts/pixl-virtual-screen-conf.sh");
                         }
                     }
 

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -178,6 +178,8 @@ FocusScope {
                             //write configuration file for virtual screens
                             //save conf
                             api.internal.recalbox.saveParameters();
+                            //change previous value
+                            previousvalue = api.internal.recalbox.getStringParameter(parameterName);
                             //Execute script to configure X11 conf
                             api.internal.system.runBoolResult("/recalbox/scripts/pixl-virtual-screen-conf.sh");
                         }

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -128,75 +128,9 @@ FocusScope {
                         }
                         container.onFocus(this)
                     }
-                    KeyNavigation.down: optVirtualDisplay
-                }
-
-                MulticheckOption {
-                    id: optVirtualDisplay
-                    //property to manage parameter name
-                    property string parameterName : "system.video.screens.virtual"
-
-                    label: qsTr("Virtual Screens (for remote display)") + api.tr
-                    note: qsTr("Select output(s) available to connect any virtual screen (need reboot)") + api.tr
-
-                    //to keep initial value and before to apply new one (to know if need reboot more than restart)
-                    property string previousvalue: api.internal.recalbox.getStringParameter(parameterName)
-
-                    value: api.internal.recalbox.parameterslist.currentNameChecked(parameterName)
-
-                    currentIndex: api.internal.recalbox.parameterslist.currentIndex;
-                    count: api.internal.recalbox.parameterslist.count;
-
-                    onActivate: {
-                        //for callback by parameterslistBox
-                        parameterscheckBox.parameterName = parameterName;
-                        parameterscheckBox.callerid = optVirtualDisplay;
-                        parameterscheckBox.isChecked = api.internal.recalbox.parameterslist.isChecked();
-                        //to force update of list of parameters
-                        api.internal.recalbox.parameterslist.currentNameChecked(parameterName);
-                        parameterscheckBox.model = api.internal.recalbox.parameterslist;
-                        parameterscheckBox.index = api.internal.recalbox.parameterslist.currentIndex;
-                        //to transfer focus to parameterscheckBox
-                        parameterscheckBox.focus = true;
-                        //to save previous value and know if we need restart or not finally
-                        parameterscheckBox.previousValue = api.internal.recalbox.getStringParameter(parameterName)
-                    }
-
-                    onValueChanged: {
-                        //console.log("previousvalue: ", previousvalue);
-                        //console.log("api.internal.recalbox.getStringParameter(parameterName): ", api.internal.recalbox.getStringParameter(parameterName));
-                        if(previousvalue !== api.internal.recalbox.getStringParameter(parameterName)){
-                            if(api.internal.recalbox.getStringParameter(parameterName).includes("|")){
-                                //add dialogBox to alert about issue if we have more than one virtual
-                                genericMessage.setSource("../../dialogs/GenericContinueDialog.qml",
-                                                         { "title": qsTr("Virtual screens alert"), "message": qsTr("Take care! Some GPU can't support multiple virtual screens") + "<br>" + qsTr("It could crash at launch (select only if you know what you do !)")});
-                                genericMessage.focus = true;
-                            }
-                            //need to reboot (or restart Xorg if possible in the future)
-                            //console.log("Need reboot");
-                            needReboot = true;
-                            //write configuration file for virtual screens
-                            //save conf
-                            api.internal.recalbox.saveParameters();
-                            //change previous value
-                            previousvalue = api.internal.recalbox.getStringParameter(parameterName);
-                            //Execute script to configure X11 conf
-                            api.internal.system.runBoolResult("/recalbox/scripts/pixl-virtual-screen-conf.sh");
-                        }
-                    }
-
-                    onFocusChanged:{
-                        if(focus){
-                            api.internal.recalbox.parameterslist.currentNameChecked(parameterName);
-                            currentIndex = api.internal.recalbox.parameterslist.currentIndex;
-                            count = api.internal.recalbox.parameterslist.count;
-                            parameterscheckBox.isChecked = api.internal.recalbox.parameterslist.isChecked();
-                        }
-                        container.onFocus(this)
-                    }
-
                     KeyNavigation.down: optPrimaryScreenActivate
                 }
+
                 // primary screen
                 ToggleOption {
                     id: optPrimaryScreenActivate
@@ -925,7 +859,141 @@ FocusScope {
                         confirmDialog.focus = true;
                     }
                     onFocusChanged: container.onFocus(this)
-                    //KeyNavigation.down: optRemoteScreenActivate
+                    KeyNavigation.down: optRemoteDisplayActivate
+                }
+
+                ToggleOption {
+                    id: optRemoteDisplayActivate
+
+                    //Remote display settings
+                    SectionTitle {
+                        text: qsTr("Remote display settings") + api.tr
+                        first: true
+                    }
+
+                    //property to manage parameter name
+                    property string parameterName : "system.remote.display.enabled"
+                    checked: api.internal.recalbox.getBoolParameter(parameterName)
+                    onCheckedChanged: {
+                            if(checked !== api.internal.recalbox.getBoolParameter(parameterName)){
+                                api.internal.recalbox.setBoolParameter(parameterName,checked);
+                                api.internal.recalbox.saveParameters();
+                            }
+                    }
+                    symbol: "\uf38c"
+                    symbolFontFamily: global.fonts.ion
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optVirtualDisplay
+                }
+
+                //virtual screens
+                MulticheckOption {
+                    id: optVirtualDisplay
+                    visible: optRemoteDisplayActivate.checked
+                    //property to manage parameter name
+                    property string parameterName : "system.video.screens.virtual"
+
+                    label: qsTr("Virtual Screens selection") + api.tr
+                    note: qsTr("Select output(s) available to connect any virtual screen (need reboot)") + api.tr
+
+                    //to keep initial value and before to apply new one (to know if need reboot more than restart)
+                    property string previousvalue: api.internal.recalbox.getStringParameter(parameterName)
+
+                    value: api.internal.recalbox.parameterslist.currentNameChecked(parameterName)
+
+                    currentIndex: api.internal.recalbox.parameterslist.currentIndex;
+                    count: api.internal.recalbox.parameterslist.count;
+
+                    onActivate: {
+                        //for callback by parameterslistBox
+                        parameterscheckBox.parameterName = parameterName;
+                        parameterscheckBox.callerid = optVirtualDisplay;
+                        parameterscheckBox.isChecked = api.internal.recalbox.parameterslist.isChecked();
+                        //to force update of list of parameters
+                        api.internal.recalbox.parameterslist.currentNameChecked(parameterName);
+                        parameterscheckBox.model = api.internal.recalbox.parameterslist;
+                        parameterscheckBox.index = api.internal.recalbox.parameterslist.currentIndex;
+                        //to transfer focus to parameterscheckBox
+                        parameterscheckBox.focus = true;
+                        //to save previous value and know if we need restart or not finally
+                        parameterscheckBox.previousValue = api.internal.recalbox.getStringParameter(parameterName)
+                    }
+
+                    onValueChanged: {
+                        //console.log("previousvalue: ", previousvalue);
+                        //console.log("api.internal.recalbox.getStringParameter(parameterName): ", api.internal.recalbox.getStringParameter(parameterName));
+                        if(previousvalue !== api.internal.recalbox.getStringParameter(parameterName)){
+                            if(api.internal.recalbox.getStringParameter(parameterName).includes("|")){
+                                //add dialogBox to alert about issue if we have more than one virtual
+                                genericMessage.setSource("../../dialogs/GenericContinueDialog.qml",
+                                                         { "title": qsTr("Virtual screens alert"), "message": qsTr("Take care! Some GPU can't support multiple virtual screens") + "<br>" + qsTr("It could crash at launch (select only if you know what you do !)")});
+                                genericMessage.focus = true;
+                            }
+                            //need to reboot (or restart Xorg if possible in the future)
+                            //console.log("Need reboot");
+                            needReboot = true;
+                            //write configuration file for virtual screens
+                            //save conf
+                            api.internal.recalbox.saveParameters();
+                            //change previous value
+                            previousvalue = api.internal.recalbox.getStringParameter(parameterName);
+                            //Execute script to configure X11 conf
+                            api.internal.system.runBoolResult("/recalbox/scripts/pixl-virtual-screen-conf.sh");
+                        }
+                    }
+
+                    onFocusChanged:{
+                        if(focus){
+                            api.internal.recalbox.parameterslist.currentNameChecked(parameterName);
+                            currentIndex = api.internal.recalbox.parameterslist.currentIndex;
+                            count = api.internal.recalbox.parameterslist.count;
+                            parameterscheckBox.isChecked = api.internal.recalbox.parameterslist.isChecked();
+                        }
+                        container.onFocus(this)
+                    }
+
+                    KeyNavigation.down: optStartWeylusService
+                }
+
+                // to validate first and second screen
+                SimpleButton {
+                    id: optStartWeylusService
+                    visible: optRemoteDisplayActivate.checked
+                    Rectangle {
+                        id: containerWeylusService
+                        width: parent.width
+                        height: parent.height
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        color: parent.focus ? themeColor.underline : themeColor.secondary
+                        opacity : parent.focus ? 1 : 0.3
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            color: themeColor.textValue
+                            font.pixelSize: vpx(30)
+                            font.family: globalFonts.ion
+                            text : "\uf2ba  " + qsTr("(Re)start remote display service") + api.tr
+                        }
+                    }
+
+                    onActivate: {
+                        //force save in recalbox.conf file before to execute script
+                        api.internal.recalbox.saveParameters();
+                        //to force change of focus
+                        confirmRestartWeylus.focus = false;
+                        confirmRestartWeylus.setSource("../../dialogs/Generic3ChoicesDialog.qml",
+                                                { "title": "Weylus service",
+                                                  "message": qsTr("Are you ready to (re)start service\nand change settings ?") + api.tr,
+                                                  "symbol": "\uf38c",
+                                                  "symbolfont" : global.fonts.ion,
+                                                  "firstchoice": qsTr("Yes") + api.tr,
+                                                  "secondchoice": "",
+                                                  "thirdchoice": qsTr("No") + api.tr});
+                        //to force change of focus
+                        confirmRestartWeylus.focus = true;
+                    }
+                    onFocusChanged: container.onFocus(this)
                 }
 
                 // "remote" screen activation (for test purpose only)
@@ -1029,6 +1097,31 @@ FocusScope {
             api.internal.system.runBoolResult("/usr/bin/externalscreen.sh");
             //and move pegasus-frontend in connected and primary screen
             api.internal.system.runBoolResult("WINDOWPID=$(xdotool search --class 'pegasus-frontend'); xdotool windowmove $WINDOWPID $(xrandr | grep -e ' connected' | grep -e 'primary' | awk '{print $4}' | awk -F'+' '{print $2, $3}');", false);
+            content.focus = true;
+        }
+    }
+
+    //loader to load confirm dialog for Weylus service
+    Loader {
+        id: confirmRestartWeylus
+        anchors.fill: parent
+        z:10
+    }
+
+    Connections {
+        target: confirmRestartWeylus.item
+        function onAccept() {
+            //restart service
+            if (!isDebugEnv()){
+                api.internal.system.run("/etc/init.d/S99weylus restart");
+            }
+            else{//for debug and see spinner
+                api.internal.system.run("sleep 5; /etc/init.d/S99weylus restart");
+            }
+            content.focus = true;
+        }
+        function onCancel() {
+            //do nothing
             content.focus = true;
         }
     }

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -166,8 +166,14 @@ FocusScope {
                         //console.log("previousvalue: ", previousvalue);
                         //console.log("api.internal.recalbox.getStringParameter(parameterName): ", api.internal.recalbox.getStringParameter(parameterName));
                         if(previousvalue !== api.internal.recalbox.getStringParameter(parameterName)){
+                            if(api.internal.recalbox.getStringParameter(parameterName).includes("|")){
+                                //add dialogBox to alert about issue if we have more than one virtual
+                                genericMessage.setSource("../../dialogs/GenericContinueDialog.qml",
+                                                         { "title": qsTr("Virtual screens alert"), "message": qsTr("Take care! Some GPU can't support multiple virtual screens") + "<br>" + qsTr("It could crash at launch (select only if you know what you do !)")});
+                                genericMessage.focus = true;
+                            }
                             //need to reboot (or restart Xorg if possible in the future)
-                            console.log("Need reboot");
+                            //console.log("Need reboot");
                             needReboot = true;
                             //write configuration file for virtual screens
                             //save conf
@@ -1045,7 +1051,7 @@ FocusScope {
             content.focus = true
             //check if need to restart to take change into account !
             if(previousValue !== api.internal.recalbox.getStringParameter(parameterName)){
-                console.log("needRestart");
+                //console.log("needRestart");
                 needRestart = true;
             }
         }

--- a/src/frontend/menu/settings/emulatorsetting/CemuSettings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/CemuSettings.qml
@@ -286,6 +286,40 @@ FocusScope {
                         api.internal.recalbox.setBoolParameter(parameterName,checked);
                     }
                     onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optRumblePower
+                }
+                SliderOption {
+                    id: optRumblePower
+
+                    //property to manage parameter name
+                    property string parameterName : "cemu.rumble"
+
+                    //property of SliderOption to set
+                    label: qsTr("Rumble power") + api.tr
+                    note: qsTr("Set power of rumble use in cemu") + api.tr
+                    // in slider object
+                    max : 100
+                    min : 0
+                    slidervalue : api.internal.recalbox.getIntParameter(parameterName,0)
+                    // in text object
+                    value: api.internal.recalbox.getIntParameter(parameterName) + "%"
+
+                    onActivate: {
+                        focus = true;
+                    }
+
+                    Keys.onLeftPressed: {
+                        api.internal.recalbox.setIntParameter(parameterName,slidervalue);
+                        value = slidervalue + "%";
+                    }
+
+                    Keys.onRightPressed: {
+                        api.internal.recalbox.setIntParameter(parameterName,slidervalue);
+                        value = slidervalue + "%";
+                    }
+
+                    onFocusChanged: container.onFocus(this)
+
                     KeyNavigation.down: optGamepadActivated
                 }
                 SectionTitle {

--- a/src/frontend/menu/settings/emulatorsetting/CemuSettings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/CemuSettings.qml
@@ -296,7 +296,7 @@ FocusScope {
 
                     //property of SliderOption to set
                     label: qsTr("Rumble power") + api.tr
-                    note: qsTr("Set power of rumble use in cemu") + api.tr
+                    note: qsTr("Set power of rumble used in cemu") + api.tr
                     // in slider object
                     max : 100
                     min : 0
@@ -311,11 +311,13 @@ FocusScope {
                     Keys.onLeftPressed: {
                         api.internal.recalbox.setIntParameter(parameterName,slidervalue);
                         value = slidervalue + "%";
+                        if(!isDebugEnv()) api.internal.system.runAsync("python /recalbox/scripts/pixl-rumble-test.py " + slidervalue + " " + slidervalue + " 300");
                     }
 
                     Keys.onRightPressed: {
                         api.internal.recalbox.setIntParameter(parameterName,slidervalue);
                         value = slidervalue + "%";
+                        if(!isDebugEnv()) api.internal.system.runAsync("python /recalbox/scripts/pixl-rumble-test.py " + slidervalue + " " + slidervalue + " 300");
                     }
 
                     onFocusChanged: container.onFocus(this)

--- a/src/frontend/menu/settings/emulatorsetting/CemuSettings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/CemuSettings.qml
@@ -361,7 +361,7 @@ FocusScope {
                 ToggleOption {
                     id: optGamepadOnSecondDisplay
 
-                    label: qsTr("Show Gamepad on second display") + api.tr
+                    label: qsTr("Show Gamepad on second display (Beta)") + api.tr
                     note: qsTr("Need to have a second display (physical or virtual) connected\nand activated from 'video configuration' to work") + api.tr
 
                     checked: api.internal.recalbox.getBoolParameter("cemu.gamepad.on.second.display",false)

--- a/src/frontend/menu/settings/emulatorsetting/CemuSettings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/CemuSettings.qml
@@ -272,6 +272,20 @@ FocusScope {
                         api.internal.recalbox.setBoolParameter("cemu.async.compile",checked);
                     }
                     onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optSDLUseButtonLabels
+                }
+                ToggleOption {
+                    id: optSDLUseButtonLabels
+
+                    property string parameterName :"cemu.use.sdl.button.labels"
+                    label: qsTr("Use SDL button labels for mappings") + api.tr
+                    note: qsTr("Feature to match button letters as requested on screen\nElse XBOX mapping will be used for all controllers") + api.tr
+                    //set env variable to SDL_GAMECONTROLLER_USE_BUTTON_LABELS=1 by default
+                    checked: api.internal.recalbox.getBoolParameter(parameterName, true)
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter(parameterName,checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
                     KeyNavigation.down: optGamepadActivated
                 }
                 SectionTitle {

--- a/src/frontend/menu/settings/emulatorsetting/CemuSettings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/CemuSettings.qml
@@ -272,7 +272,54 @@ FocusScope {
                         api.internal.recalbox.setBoolParameter("cemu.async.compile",checked);
                     }
                     onFocusChanged: container.onFocus(this)
-//                    KeyNavigation.down: optAutoSave
+                    KeyNavigation.down: optGamepadActivated
+                }
+                SectionTitle {
+                    text: qsTr("Gamepad screen") + api.tr
+                    first: true
+                    symbol: "\uf2ea"
+                    symbolFontFamily: globalFonts.awesome
+                    symbolFontSize: vpx(45)
+                }
+                ToggleOption {
+                    id: optGamepadActivated
+
+                    label: qsTr("Enable Wii U Gamepad") + api.tr
+                    note: qsTr("Activate Wii U Gamepad usage in game") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("cemu.gamepad.activated",false)
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("cemu.gamepad.activated",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optGamepadAtStart
+                }
+                ToggleOption {
+                    id: optGamepadAtStart
+
+                    label: qsTr("Show Gamepad at start") + api.tr
+                    note: qsTr("Show gamepad window at front of game window and at start\n(else could be show/hide using HOTKEY+R1)") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("cemu.gamepad.at.start",false)
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("cemu.gamepad.at.start",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    visible: optGamepadActivated.checked
+                    KeyNavigation.down: optGamepadOnSecondDisplay
+                }
+                ToggleOption {
+                    id: optGamepadOnSecondDisplay
+
+                    label: qsTr("Show Gamepad on second display") + api.tr
+                    note: qsTr("Need to have a second display (physical or virtual) connected\nand activated from 'video configuration' to work") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("cemu.gamepad.on.second.display",false)
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("cemu.gamepad.on.second.display",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    visible: optGamepadActivated.checked
                 }
                 Item {
                     width: parent.width

--- a/src/frontend/menu/settings/emulatorsetting/CitraSettings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/CitraSettings.qml
@@ -181,23 +181,36 @@ FocusScope {
                         }
                         container.onFocus(this)
                     }
-                    KeyNavigation.down: optBottomSreenPosition
+                    KeyNavigation.down: optOnSecondDisplay
                 }
                 SectionTitle {
-                    text: qsTr("Bottom screen") + api.tr
+                    text: qsTr("Screens") + api.tr
                     first: true
                     symbol: "\uf28e"
                     symbolFontFamily: globalFonts.awesome
                     symbolFontSize: vpx(45)
                 }
+                ToggleOption {
+                    id: optOnSecondDisplay
+
+                    label: qsTr("Show 3DS bottom screen on a second display") + api.tr
+                    note: qsTr("Need to have a second display (physical or virtual) connected\nand activated from 'video configuration' to work") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("citra.bottom.screen.on.second.display",false)
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("citra.bottom.screen.on.second.display",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optBottomScreenPosition
+                }
                 MultivalueOption {
-                    id: optBottomSreenPosition
+                    id: optBottomScreenPosition
 
                     //property to manage parameter name
-                    property string parameterName : "citra.bottom.screen.position"
+                    property string parameterName : "citra.screens.layout"
 
-                    label: qsTr("Bottom Screen position") + api.tr
-                    note: qsTr("To set position of bottom screen at start on primary dislpay") + api.tr
+                    label: qsTr("Screens layout") + api.tr
+                    note: qsTr("To set position of screens at start on primary display") + api.tr
 
                     value: api.internal.recalbox.parameterslist.currentName(parameterName)
 
@@ -207,7 +220,7 @@ FocusScope {
                     onActivate: {
                         //for callback by parameterslistBox
                         parameterslistBox.parameterName = parameterName;
-                        parameterslistBox.callerid = optBottomSreenPosition;
+                        parameterslistBox.callerid = optBottomScreenPosition;
                         //to force update of list of parameters
                         api.internal.recalbox.parameterslist.currentName(parameterName);
                         parameterslistBox.model = api.internal.recalbox.parameterslist;
@@ -233,19 +246,7 @@ FocusScope {
                         }
                         container.onFocus(this)
                     }
-                    KeyNavigation.down: optOnSecondDisplay
-                }
-                ToggleOption {
-                    id: optOnSecondDisplay
-
-                    label: qsTr("Show 3DS bottom screen on a second display") + api.tr
-                    note: qsTr("Need to have a second display (physical or virtual) connected\nand activated from 'video configuration' to work") + api.tr
-
-                    checked: api.internal.recalbox.getBoolParameter("citra.bottom.screen.on.second.display",false)
-                    onCheckedChanged: {
-                        api.internal.recalbox.setBoolParameter("citra.bottom.screen.on.second.display",checked);
-                    }
-                    onFocusChanged: container.onFocus(this)
+                    visible: !optOnSecondDisplay.checked
                 }
                 Item {
                     width: parent.width

--- a/src/frontend/menu/settings/emulatorsetting/CitraSettings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/CitraSettings.qml
@@ -193,7 +193,7 @@ FocusScope {
                 ToggleOption {
                     id: optOnSecondDisplay
 
-                    label: qsTr("Show 3DS bottom screen on a second display") + api.tr
+                    label: qsTr("Show 3DS bottom screen on a second display (Beta)") + api.tr
                     note: qsTr("Need to have a second display (physical or virtual) connected\nand activated from 'video configuration' to work") + api.tr
 
                     checked: api.internal.recalbox.getBoolParameter("citra.bottom.screen.on.second.display",false)

--- a/src/frontend/menu/settings/emulatorsetting/CitraSettings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/CitraSettings.qml
@@ -181,8 +181,71 @@ FocusScope {
                         }
                         container.onFocus(this)
                     }
+                    KeyNavigation.down: optBottomSreenPosition
+                }
+                SectionTitle {
+                    text: qsTr("Bottom screen") + api.tr
+                    first: true
+                    symbol: "\uf28e"
+                    symbolFontFamily: globalFonts.awesome
+                    symbolFontSize: vpx(45)
+                }
+                MultivalueOption {
+                    id: optBottomSreenPosition
 
-//                    KeyNavigation.down: optCheats
+                    //property to manage parameter name
+                    property string parameterName : "citra.bottom.screen.position"
+
+                    label: qsTr("Bottom Screen position") + api.tr
+                    note: qsTr("To set position of bottom screen at start on primary dislpay") + api.tr
+
+                    value: api.internal.recalbox.parameterslist.currentName(parameterName)
+
+                    currentIndex: api.internal.recalbox.parameterslist.currentIndex;
+                    count: api.internal.recalbox.parameterslist.count;
+
+                    onActivate: {
+                        //for callback by parameterslistBox
+                        parameterslistBox.parameterName = parameterName;
+                        parameterslistBox.callerid = optBottomSreenPosition;
+                        //to force update of list of parameters
+                        api.internal.recalbox.parameterslist.currentName(parameterName);
+                        parameterslistBox.model = api.internal.recalbox.parameterslist;
+                        parameterslistBox.index = api.internal.recalbox.parameterslist.currentIndex;
+                        //to transfer focus to parameterslistBox
+                        parameterslistBox.focus = true;
+                    }
+
+                    onSelect: {
+                        //to force to be on the good parameter selected
+                        api.internal.recalbox.parameterslist.currentName(parameterName);
+                        //to update index of parameterlist QAbstractList
+                        api.internal.recalbox.parameterslist.currentIndex = index;
+                        //to force update of display of selected value
+                        value = api.internal.recalbox.parameterslist.currentName(parameterName);
+                    }
+
+                    onFocusChanged:{
+                        if(focus){
+                            api.internal.recalbox.parameterslist.currentName(parameterName);
+                            currentIndex = api.internal.recalbox.parameterslist.currentIndex;
+                            count = api.internal.recalbox.parameterslist.count;
+                        }
+                        container.onFocus(this)
+                    }
+                    KeyNavigation.down: optOnSecondDisplay
+                }
+                ToggleOption {
+                    id: optOnSecondDisplay
+
+                    label: qsTr("Show 3DS bottom screen on a second display") + api.tr
+                    note: qsTr("Need to have a second display (physical or virtual) connected\nand activated from 'video configuration' to work") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("citra.bottom.screen.on.second.display",false)
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("citra.bottom.screen.on.second.display",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
                 }
                 Item {
                     width: parent.width


### PR DESCRIPTION
	- "Second Screen" in game features (Beta):
		- add parameter to select virtual screen(s)
		- add script called after configuration change to prepare conf before reboot
		- alert for more than one virtual screen
		- finalize parameters to manage layout/second display
		- add menu for remote display and weylus service (re)start
		- add "(Beta)" annotations for some advanced features for the moment 
		- For cemu:
			- add parameters to manage wii u gamepad display
			- add advanced parameter to manage mapping using SDL Button labels
			- add rumble power to manage rumble for controllers compatible
			- add rumble simulation from menu using a script
		- For Citra:
			- add parameters to manage 3ds bottom screen display
			- finalize parameters to manage layout/second display