### PR TITLE
 second/virtual screen feature (Beta feature) - phase 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ All notable changes to this project will be documented in this file (focus on ch
     - add "pixL patches" repository for updates
 	- add usage of MegaBezel shaders using our overlays (reflections, glass ...) by system/custom overlays
 	- fix to add possibility to use SSID in parts separated with spaces (until 6)
-
+	- second/virtual screen feature (Beta feature):
+		- add feature to take into account also disconnected screens with resolutions/frequences
+		- fix to add more tmp file generation during changes to improve refresh of info in UI
+		- for virtual, return now only virtual (for intel) or disconnected ones (for nvidia/amd) in case of virtual outputs
+		- fix to reboot only for nvidia GPU to setup virtual screens for the moment 
+		- fix to propose to reboot only for nvidia GPU to setup virtual screens for the moment
+		- filter better NVIDIA vs INTEL/AMD outputs
+		
 ## [pixL-master] - 2024-12-24 - v0.1.9
 - Features:
 	- add auto change disc option on dolphin

--- a/src/backend/model/internal/settings/ParametersList.cpp
+++ b/src/backend/model/internal/settings/ParametersList.cpp
@@ -149,7 +149,8 @@ QStringList GetParametersList(QString Parameter)
     {
         //need to list all existing outputs and store it in list of check boxes
         // command to get all lines with "connected" and "disconnected" + remove "primary" screen
-        QString SysCommand = "grep -v 'primary' /tmp/xrandr.tmp | awk '$2 ~ \"connected\" {print $1}'";
+        //QString SysCommand = "grep -v 'primary' /tmp/xrandr.tmp | awk '$2 ~ \"connected\" {print $1}'";
+        QString SysCommand = "grep -v 'primary' /tmp/xrandr.tmp | grep -q 'VIRTUAL' && xrandr | grep 'VIRTUAL' | grep 'connected' | awk '{print $1}' || xrandr | grep ' disconnected' | awk '{print $1}'";
         ListOfValue = GetParametersListFromSystem(Parameter, SysCommand);
     }
     else if (Parameter == "system.secondary.screen.position")

--- a/src/backend/model/internal/settings/ParametersList.cpp
+++ b/src/backend/model/internal/settings/ParametersList.cpp
@@ -149,8 +149,8 @@ QStringList GetParametersList(QString Parameter)
     {
         //need to list all existing outputs and store it in list of check boxes
         // command to get all lines with "connected" and "disconnected" + remove "primary" screen
-        //QString SysCommand = "grep -v 'primary' /tmp/xrandr.tmp | awk '$2 ~ \"connected\" {print $1}'";
-        QString SysCommand = "grep -v 'primary' /tmp/xrandr.tmp | grep -q 'VIRTUAL' && xrandr | grep 'VIRTUAL' | grep 'connected' | awk '{print $1}' || xrandr | grep ' disconnected' | awk '{print $1}'";
+        QString SysCommand = "grep -v 'primary' /tmp/xrandr.tmp | grep -q 'VIRTUAL' && grep 'VIRTUAL' /tmp/xrandr.tmp | grep 'connected' | awk '{print $1}' || grep -v 'primary' /tmp/xrandr.tmp | grep 'connected' | awk '{print $1}'";
+
         ListOfValue = GetParametersListFromSystem(Parameter, SysCommand);
     }
     else if (Parameter == "system.secondary.screen.position")

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -236,7 +236,8 @@ FocusScope {
                     property string previousvalue: api.internal.recalbox.getStringParameter(parameterName)
 
                     property variant optionsList : [optDisplayOutput.value]
-                    property string command : "awk -v monitor=\"^%1 connected\" '/connected/ {p = 0} $0 ~ monitor {p = 1} p' /tmp/xrandr.tmp | awk '{if(NR>1)print $1}'"
+                    //31/12/2024: command changed to get "disconnected" ones also with modeline added as for virtul screens
+                    property string command : "awk -v monitor=\"^%1 \" '/connected/ {p = 0} $0 ~ monitor {p = 1} p' /tmp/xrandr.tmp | awk '{if(NR>1)print $1}'"
 
                     label: qsTr("Resolution") + api.tr
                     note: qsTr("Choose resolution for your primary screen.") + api.tr
@@ -314,7 +315,8 @@ FocusScope {
                     property string previousvalue: api.internal.recalbox.getStringParameter(parameterName)
 
                     property variant optionsList : [optDisplayOutput.value, optDisplayResolution.value]
-                    property string command : "awk -v monitor=\"^%1 connected\" '/connected/ {p = 0} $0 ~ monitor {p = 1} p' /tmp/xrandr.tmp | awk '{if(NR>1) print}' | awk '$1 == \"%2\" {print}' | awk '{for (i=2; i<=NF; i++) print $i}' | tr -d '+*'"
+                    //31/12/2024: command changed to get "disconnected" ones also with modeline added as for virtul screens
+                    property string command : "awk -v monitor=\"^%1 \" '/connected/ {p = 0} $0 ~ monitor {p = 1} p' /tmp/xrandr.tmp | awk '{if(NR>1) print}' | awk '$1 == \"%2\" {print}' | awk '{for (i=2; i<=NF; i++) print $i}' | tr -d '+*'"
                     label: qsTr("Frequency") + api.tr
                     note: qsTr("Choose frequency for your primary screen.") + api.tr
 
@@ -541,7 +543,8 @@ FocusScope {
                     property string previousvalue: api.internal.recalbox.getStringParameter(parameterName)
 
                     property variant optionsList : [optDisplaySecondaryOutput.value]
-                    property string command : "awk -v monitor=\"^%1 connected\" '/connected/ {p = 0} $0 ~ monitor {p = 1} p' /tmp/xrandr.tmp | awk '{if(NR>1)print $1}'"
+                    //31/12/2024: command changed to get "disconnected" ones also with modeline added as for virtul screens
+                    property string command : "awk -v monitor=\"^%1 \" '/connected/ {p = 0} $0 ~ monitor {p = 1} p' /tmp/xrandr.tmp | awk '{if(NR>1)print $1}'"
 
                     label: qsTr("Resolution") + api.tr
                     note: qsTr("Choose resolution for secondary screen.") + api.tr
@@ -616,7 +619,8 @@ FocusScope {
                     property string previousvalue: api.internal.recalbox.getStringParameter(parameterName)
 
                     property variant optionsList : [optDisplaySecondaryOutput.value, optDisplaySecondaryResolution.value]
-                    property string command : "awk -v monitor=\"^%1 connected\" '/connected/ {p = 0} $0 ~ monitor {p = 1} p' /tmp/xrandr.tmp | awk '{if(NR>1) print}' | awk '$1 == \"%2\" {print}' | awk '{for (i=2; i<=NF; i++) print $i}' | tr -d '+*'"
+                    //31/12/2024: command changed to get "disconnected" ones also with modeline added as for virtul screens
+                    property string command : "awk -v monitor=\"^%1 \" '/connected/ {p = 0} $0 ~ monitor {p = 1} p' /tmp/xrandr.tmp | awk '{if(NR>1) print}' | awk '$1 == \"%2\" {print}' | awk '{for (i=2; i<=NF; i++) print $i}' | tr -d '+*'"
 
                     label: qsTr("Frequency") + api.tr
                     note: qsTr("Choose frequency for secondary screen.") + api.tr

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -933,9 +933,11 @@ FocusScope {
                                                          { "title": qsTr("Virtual screens alert"), "message": qsTr("Take care! Some GPU can't support multiple virtual screens") + "<br>" + qsTr("It could crash at launch (select only if you know what you do !)")});
                                 genericMessage.focus = true;
                             }
-                            //need to reboot (or restart Xorg if possible in the future)
-                            //console.log("Need reboot");
-                            needReboot = true;
+                            //need to reboot for Nvidia changes for the moment (or restart Xorg if possible in the future)
+                            if(api.internal.system.run("lspci | grep -i 'VGA' | grep -i 'nvidia' | wc -l | tr -d '\\n' | tr -d '\\r'") === "1") {
+                                //console.log("Need reboot");
+                                needReboot = true;
+                            }
                             //write configuration file for virtual screens
                             //save conf
                             api.internal.recalbox.saveParameters();
@@ -1148,11 +1150,6 @@ FocusScope {
 
         onClose: {
             content.focus = true
-            //check if need to restart to take change into account !
-            if(previousValue !== api.internal.recalbox.getStringParameter(parameterName)){
-                //console.log("needRestart");
-                needRestart = true;
-            }
         }
 
         onCheck: {

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -843,8 +843,8 @@ FocusScope {
                         }
                         //force save in recalbox.conf file before to execute script
                         api.internal.recalbox.saveParameters();
-                        //Execute script to udpate screen settings in real-time
-                        api.internal.system.runBoolResult("/usr/bin/externalscreen.sh");
+                        //Execute script to udpate screen settings in real-time + update xrandr info just after
+                        api.internal.system.runBoolResult("/usr/bin/externalscreen.sh;xrandr>/tmp/xrandr.tmp");
                         //and move pegasus-frontend in connected and primary screen
                         api.internal.system.runBoolResult("WINDOWPID=$(xdotool search --class 'pegasus-frontend'); xdotool windowmove $WINDOWPID $(xrandr | grep -e ' connected' | grep -e 'primary' | awk '{print $4}' | awk -F'+' '{print $2, $3}');", false);
 
@@ -941,8 +941,8 @@ FocusScope {
                             api.internal.recalbox.saveParameters();
                             //change previous value
                             previousvalue = api.internal.recalbox.getStringParameter(parameterName);
-                            //Execute script to configure X11 conf
-                            api.internal.system.runBoolResult("/recalbox/scripts/pixl-virtual-screen-conf.sh");
+                            //Execute script to configure X11 conf + update xrandr info just after
+                            api.internal.system.runBoolResult("/recalbox/scripts/pixl-virtual-screen-conf.sh;xrandr>/tmp/xrandr.tmp");
                         }
                     }
 
@@ -1097,8 +1097,8 @@ FocusScope {
 
             //re-save conf
             api.internal.recalbox.saveParameters();
-            //Execute script to restore screen openVideoSettings
-            api.internal.system.runBoolResult("/usr/bin/externalscreen.sh");
+            //Execute script to restore screen openVideoSettings + update xrandr info just after
+            api.internal.system.runBoolResult("/usr/bin/externalscreen.sh;xrandr>/tmp/xrandr.tmp");
             //and move pegasus-frontend in connected and primary screen
             api.internal.system.runBoolResult("WINDOWPID=$(xdotool search --class 'pegasus-frontend'); xdotool windowmove $WINDOWPID $(xrandr | grep -e ' connected' | grep -e 'primary' | awk '{print $4}' | awk -F'+' '{print $2, $3}');", false);
             content.focus = true;

--- a/src/frontend/menu/settings/VideoSettings.qml
+++ b/src/frontend/menu/settings/VideoSettings.qml
@@ -898,7 +898,7 @@ FocusScope {
                     property string parameterName : "system.video.screens.virtual"
 
                     label: qsTr("Virtual Screens selection") + api.tr
-                    note: qsTr("Select output(s) available to connect any virtual screen (need reboot)") + api.tr
+                    note: qsTr("Select output(s) available to connect any virtual screen\n(need reboot for NVIDIA GPU)") + api.tr
 
                     //to keep initial value and before to apply new one (to know if need reboot more than restart)
                     property string previousvalue: api.internal.recalbox.getStringParameter(parameterName)


### PR DESCRIPTION
	- second/virtual screen feature (Beta feature):
		- add feature to take into account also disconnected screens with resolutions/frequences
		- fix to add more tmp file generation during changes to improve refresh of info in UI
		- for virtual, return now only virtual (for intel) or disconnected ones (for nvidia/amd) in case of virtual outputs
		- fix to reboot only for nvidia GPU to setup virtual screens for the moment 
		- fix to propose to reboot only for nvidia GPU to setup virtual screens for the moment
		- filter better NVIDIA vs INTEL/AMD outputs