### PR TITLE
more options for ps2/pcsx2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file (focus on ch
 		- filter better NVIDIA vs INTEL/AMD outputs
 	- add overlay suppport option in menu for Sony PS2 including libretro core and PCSX2 sandalone emulator 
 	- add crosshairs option in menu for PCSX2 standalone emulator
+	- add split screen hack/fullstretch options in menu for PCSX2 standalone emulator
 
 ## [pixL-master] - 2024-12-24 - v0.1.9
 - Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ All notable changes to this project will be documented in this file (focus on ch
 		- fix to reboot only for nvidia GPU to setup virtual screens for the moment 
 		- fix to propose to reboot only for nvidia GPU to setup virtual screens for the moment
 		- filter better NVIDIA vs INTEL/AMD outputs
-		
+	- add overlay suppport option in menu for Sony PS2 including libretro core and PCSX2 sandalone emulator 
+	- add crosshairs option in menu for PCSX2 standalone emulator
+
 ## [pixL-master] - 2024-12-24 - v0.1.9
 - Features:
 	- add auto change disc option on dolphin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file (focus on change done on recalbox-integration branch).
 
-## [pixL-master] - 2025-mm-dd - v0.x.x
+## [pixL-master] - 2025-03-01 - v0.1.10
 - Features:
 	- add Amazon Luna controller layout
 	- update ratio Google Stadia
@@ -15,9 +15,14 @@ All notable changes to this project will be documented in this file (focus on ch
 		- fix to reboot only for nvidia GPU to setup virtual screens for the moment 
 		- fix to propose to reboot only for nvidia GPU to setup virtual screens for the moment
 		- filter better NVIDIA vs INTEL/AMD outputs
-	- add overlay suppport option in menu for Sony PS2 including libretro core and PCSX2 sandalone emulator 
-	- add crosshairs option in menu for PCSX2 standalone emulator
-	- add split screen hack/fullstretch options in menu for PCSX2 standalone emulator
+	- PS2 features:
+		- add overlay support option in menu for Sony PS2 including libretro core and PCSX2 sandalone emulator 
+		- add crosshairs option in menu for PCSX2 standalone emulator
+		- add split screen hack/fullstretch options in menu for PCSX2 standalone emulator
+		- add "GUI at start", "fast boot" and "inject system language in BIOS" from PCSX2 menu
+		- add possibility to launch PS2 BIOS from Pegasus menu
+		- clarify asia BIOS usage + add more comments
+		- add more comment/warning about "fast boot" feature
 
 ## [pixL-master] - 2024-12-24 - v0.1.9
 - Features:

--- a/src/frontend/menu/settings/SystemsEmulatorConfiguration.qml
+++ b/src/frontend/menu/settings/SystemsEmulatorConfiguration.qml
@@ -427,6 +427,9 @@ FocusScope {
                                       case 'dolphin-triforce':
                                           hasOverlaySupport = true;
                                         break;
+                                      case 'pcsx2':
+                                          hasOverlaySupport = true;
+                                        break;
                                       default:
                                           hasOverlaySupport = false;
                                     }

--- a/src/frontend/menu/settings/emulatorsetting/Pcsx2Settings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/Pcsx2Settings.qml
@@ -355,7 +355,7 @@ FocusScope {
                     id: optFastBoot
 
                     label: qsTr("Fast Boot") + api.tr
-                    note: qsTr("To start game direclty without Bios loading introduction") + api.tr
+                    note: qsTr("To start game directly without Bios loading introduction\n(Not compatible with all games/hacks)") + api.tr
 
                     checked: api.internal.recalbox.getBoolParameter("pcsx2.fastboot",false)
                     onCheckedChanged: {

--- a/src/frontend/menu/settings/emulatorsetting/Pcsx2Settings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/Pcsx2Settings.qml
@@ -240,7 +240,19 @@ FocusScope {
                         }
                         container.onFocus(this)
                     }
+                    KeyNavigation.down: optGUI
+                }
+                ToggleOption {
+                    id: optGUI
 
+                    label: qsTr("Enable Graphical User Interface at start") + api.tr
+                    note: qsTr("To access PCSX2 GUI at start") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("pcsx2.gui",false)
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("pcsx2.gui",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
                     KeyNavigation.down: optCrosshairs
                 }
                 SectionTitle {
@@ -255,7 +267,7 @@ FocusScope {
                     label: qsTr("Crosshairs") + api.tr
                     note: qsTr("Active crosshairs on lightgun games.") + api.tr
 
-                    checked: api.internal.recalbox.getBoolParameter("pcsx2.crosshairs")
+                    checked: api.internal.recalbox.getBoolParameter("pcsx2.crosshairs",true)
                     onCheckedChanged: {
                         api.internal.recalbox.setBoolParameter("pcsx2.crosshairs",checked);
                     }
@@ -268,7 +280,7 @@ FocusScope {
                     label: qsTr("Split screen hack (Beta)") + api.tr
                     note: qsTr("Hack to be able to play to split screen games as Time Crisis games\n(will be activated only if 2 guns connected)") + api.tr
 
-                    checked: api.internal.recalbox.getBoolParameter("pcsx2.splitscreen.hack")
+                    checked: api.internal.recalbox.getBoolParameter("pcsx2.splitscreen.hack",true)
                     onCheckedChanged: {
                         api.internal.recalbox.setBoolParameter("pcsx2.splitscreen.hack",checked);
                     }
@@ -281,7 +293,7 @@ FocusScope {
                     label: qsTr("Split screen full stretch (Beta)") + api.tr
                     note: qsTr("To maximize high of game view for split screen games\n(but not adviced to keep good ratio)") + api.tr
 
-                    checked: api.internal.recalbox.getBoolParameter("pcsx2.splitscreen.fullstretch")
+                    checked: api.internal.recalbox.getBoolParameter("pcsx2.splitscreen.fullstretch",false)
                     onCheckedChanged: {
                         api.internal.recalbox.setBoolParameter("pcsx2.splitscreen.fullstretch",checked);
                     }
@@ -299,9 +311,35 @@ FocusScope {
                     label: qsTr("Enable Cheats") + api.tr
                     note: qsTr("Ingames cheats enable.") + api.tr
 
-                    checked: api.internal.recalbox.getBoolParameter("pcsx2.cheats")
+                    checked: api.internal.recalbox.getBoolParameter("pcsx2.cheats",false)
                     onCheckedChanged: {
                         api.internal.recalbox.setBoolParameter("pcsx2.cheats",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optFastBoot
+                }
+                ToggleOption {
+                    id: optFastBoot
+
+                    label: qsTr("Fast Boot") + api.tr
+                    note: qsTr("To start game direclty without Bios loading introduction") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("pcsx2.fastboot",false)
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("pcsx2.fastboot",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optInjectSystemLanguage
+                }
+                ToggleOption {
+                    id: optInjectSystemLanguage
+
+                    label: qsTr("Inject System Language in BIOS") + api.tr
+                    note: qsTr("Set PS2 BIOS System language from pixL's one") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("pcsx2.injectsystemlanguage",true)
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("pcsx2.injectsystemlanguage",checked);
                     }
                     onFocusChanged: container.onFocus(this)
                 }

--- a/src/frontend/menu/settings/emulatorsetting/Pcsx2Settings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/Pcsx2Settings.qml
@@ -12,6 +12,38 @@ import QtQuick.Window 2.12
 FocusScope {
     id: root
 
+    //to be able to have region selected
+    property string region : ""
+
+    //loader to load confirm dialog
+    Loader {
+        id: launchPS2BIOS
+        anchors.fill: parent
+        z:10
+    }
+
+    Connections {
+        target: launchPS2BIOS.item
+        function onAccept() {
+            //launch "game" to use BIOS
+            //just set "bios" as title of this game (optional)
+            api.internal.singleplay.setTitle("bios(" + region + ")");
+            //set rom full path (fake rom with "bios(region)" in this case)
+            api.internal.singleplay.setFile("/recalbox/share/roms/ps2/bios(" + region + ")");
+            //set system to select to run this rom
+            api.internal.singleplay.setSystem("ps2"); //using shortName
+            //connect game to launcher
+            api.connectGameFiles(api.internal.singleplay.game);
+            //launch this Game
+            api.internal.singleplay.game.launch();
+            content.focus = true;
+        }
+        function onCancel() {
+            //do nothing
+            content.focus = true;
+        }
+    }
+
     signal close
 
     width: parent.width
@@ -342,7 +374,161 @@ FocusScope {
                         api.internal.recalbox.setBoolParameter("pcsx2.injectsystemlanguage",checked);
                     }
                     onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: btnLaunchEuropeBIOS
                 }
+                // to apply settings
+                SimpleButton {
+                    id: btnLaunchEuropeBIOS
+                    Rectangle {
+                        //id: containerValidate
+                        width: parent.width
+                        height: parent.height
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        color: parent.focus ? themeColor.underline : themeColor.secondary
+                        opacity : parent.focus ? 1 : 0.3
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            color: themeColor.textValue
+                            font.pixelSize: vpx(30)
+                            font.family: globalFonts.ion
+                            text : "\uf2ba  " + qsTr("Launch PS2 BIOS - Europe (to configure)") + api.tr
+                        }
+                    }
+                    onActivate: {
+                        //to force change of focus
+                        launchPS2BIOS.focus = false;
+                        launchPS2BIOS.setSource("../../../dialogs/Generic3ChoicesDialog.qml",
+                                                { "title": "PS2 BIOS (Europe)",
+                                                  "message": qsTr("Do you want to launch this BIOS now ?") + api.tr,
+                                                  "symbol": "\uf412",
+                                                  "symbolfont" : global.fonts.ion,
+                                                  "firstchoice": qsTr("Yes") + api.tr,
+                                                  "secondchoice": "",
+                                                  "thirdchoice": qsTr("No") + api.tr});
+                        //Save region selected for later
+                        region = "europe";
+                        //to force change of focus
+                        launchPS2BIOS.focus = true;
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: btnLaunchJapanBIOS
+                }
+                SimpleButton {
+                    id: btnLaunchJapanBIOS
+                    Rectangle {
+                        //id: containerValidate
+                        width: parent.width
+                        height: parent.height
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        color: parent.focus ? themeColor.underline : themeColor.secondary
+                        opacity : parent.focus ? 1 : 0.3
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            color: themeColor.textValue
+                            font.pixelSize: vpx(30)
+                            font.family: globalFonts.ion
+                            text : "\uf2ba  " + qsTr("Launch PS2 BIOS - Japan (to configure)") + api.tr
+                        }
+                    }
+                    onActivate: {
+                        //to force change of focus
+                        launchPS2BIOS.focus = false;
+                        launchPS2BIOS.setSource("../../../dialogs/Generic3ChoicesDialog.qml",
+                                                { "title": "PS2 BIOS (Japan)",
+                                                  "message": qsTr("Do you want to launch this BIOS now ?") + api.tr,
+                                                  "symbol": "\uf412",
+                                                  "symbolfont" : global.fonts.ion,
+                                                  "firstchoice": qsTr("Yes") + api.tr,
+                                                  "secondchoice": "",
+                                                  "thirdchoice": qsTr("No") + api.tr});
+                        //Save region selected for later
+                        region = "japan";
+                        //to force change of focus
+                        launchPS2BIOS.focus = true;
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: btnLaunchUsaBIOS
+                }
+                SimpleButton {
+                    id: btnLaunchUsaBIOS
+                    Rectangle {
+                        //id: containerValidate
+                        width: parent.width
+                        height: parent.height
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        color: parent.focus ? themeColor.underline : themeColor.secondary
+                        opacity : parent.focus ? 1 : 0.3
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            color: themeColor.textValue
+                            font.pixelSize: vpx(30)
+                            font.family: globalFonts.ion
+                            text : "\uf2ba  " + qsTr("Launch PS2 BIOS - USA (to configure)") + api.tr
+                        }
+                    }
+                    onActivate: {
+                        //to force change of focus
+                        launchPS2BIOS.focus = false;
+                        launchPS2BIOS.setSource("../../../dialogs/Generic3ChoicesDialog.qml",
+                                                { "title": "PS2 BIOS (USA)",
+                                                  "message": qsTr("Do you want to launch this BIOS now ?") + api.tr,
+                                                  "symbol": "\uf412",
+                                                  "symbolfont" : global.fonts.ion,
+                                                  "firstchoice": qsTr("Yes") + api.tr,
+                                                  "secondchoice": "",
+                                                  "thirdchoice": qsTr("No") + api.tr});
+                        //Save region selected for later
+                        region = "usa";
+                        //to force change of focus
+                        launchPS2BIOS.focus = true;
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: btnLaunchHongKongBIOS
+                }
+                SimpleButton {
+                    id: btnLaunchHongKongBIOS
+                    Rectangle {
+                        id: containerValidate
+                        width: parent.width
+                        height: parent.height
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        color: parent.focus ? themeColor.underline : themeColor.secondary
+                        opacity : parent.focus ? 1 : 0.3
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            color: themeColor.textValue
+                            font.pixelSize: vpx(30)
+                            font.family: globalFonts.ion
+                            text : "\uf2ba  " + qsTr("Launch PS2 BIOS - Hong Kong (to configure)") + api.tr
+                        }
+                    }
+                    onActivate: {
+                        //to force change of focus
+                        launchPS2BIOS.focus = false;
+                        launchPS2BIOS.setSource("../../../dialogs/Generic3ChoicesDialog.qml",
+                                                { "title": "PS2 BIOS (Hong Kong)",
+                                                  "message": qsTr("Do you want to launch this BIOS now ?") + api.tr,
+                                                  "symbol": "\uf412",
+                                                  "symbolfont" : global.fonts.ion,
+                                                  "firstchoice": qsTr("Yes") + api.tr,
+                                                  "secondchoice": "",
+                                                  "thirdchoice": qsTr("No") + api.tr});
+                        //Save region selected for later
+                        region = "china";
+                        //to force change of focus
+                        launchPS2BIOS.focus = true;
+                    }
+                    onFocusChanged: container.onFocus(this)
+                }
+
                 Item {
                     width: parent.width
                     height: implicitHeight + vpx(30)

--- a/src/frontend/menu/settings/emulatorsetting/Pcsx2Settings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/Pcsx2Settings.qml
@@ -241,6 +241,19 @@ FocusScope {
                         container.onFocus(this)
                     }
 
+                    KeyNavigation.down: optCrosshairs
+                }
+                ToggleOption {
+                    id: optCrosshairs
+
+                    label: qsTr("Crosshairs") + api.tr
+                    note: qsTr("Active crosshairs on lightgun games.") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("pcsx2.crosshairs")
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("pcsx2.crosshairs",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
                     KeyNavigation.down: optCheats
                 }
                 SectionTitle {
@@ -259,7 +272,6 @@ FocusScope {
                         api.internal.recalbox.setBoolParameter("pcsx2.cheats",checked);
                     }
                     onFocusChanged: container.onFocus(this)
-//                    KeyNavigation.down: optAutoSave
                 }
                 Item {
                     width: parent.width

--- a/src/frontend/menu/settings/emulatorsetting/Pcsx2Settings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/Pcsx2Settings.qml
@@ -243,6 +243,12 @@ FocusScope {
 
                     KeyNavigation.down: optCrosshairs
                 }
+                SectionTitle {
+                    text: qsTr("Lightguns") + api.tr
+                    first: true
+                    symbol: "\uf0d0"
+                    symbolFontFamily: global.fonts.awesome //global.fonts.ion is used by default
+                }
                 ToggleOption {
                     id: optCrosshairs
 
@@ -252,6 +258,32 @@ FocusScope {
                     checked: api.internal.recalbox.getBoolParameter("pcsx2.crosshairs")
                     onCheckedChanged: {
                         api.internal.recalbox.setBoolParameter("pcsx2.crosshairs",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optSplitscreenHack
+                }
+                ToggleOption {
+                    id: optSplitscreenHack
+
+                    label: qsTr("Split screen hack (Beta)") + api.tr
+                    note: qsTr("Hack to be able to play to split screen games as Time Crisis games\n(will be activated only if 2 guns connected)") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("pcsx2.splitscreen.hack")
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("pcsx2.splitscreen.hack",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optSplitscreenFullStretch
+                }
+                ToggleOption {
+                    id: optSplitscreenFullStretch
+                    visible: optSplitscreenHack.checked
+                    label: qsTr("Split screen full stretch (Beta)") + api.tr
+                    note: qsTr("To maximize high of game view for split screen games\n(but not adviced to keep good ratio)") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("pcsx2.splitscreen.fullstretch")
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("pcsx2.splitscreen.fullstretch",checked);
                     }
                     onFocusChanged: container.onFocus(this)
                     KeyNavigation.down: optCheats

--- a/src/frontend/menu/settings/emulatorsetting/Pcsx2Settings.qml
+++ b/src/frontend/menu/settings/emulatorsetting/Pcsx2Settings.qml
@@ -29,6 +29,7 @@ FocusScope {
             //just set "bios" as title of this game (optional)
             api.internal.singleplay.setTitle("bios(" + region + ")");
             //set rom full path (fake rom with "bios(region)" in this case)
+            //important to have paranthesis around the region and the "bios" term to be well detected by configgen
             api.internal.singleplay.setFile("/recalbox/share/roms/ps2/bios(" + region + ")");
             //set system to select to run this rom
             api.internal.singleplay.setSystem("ps2"); //using shortName
@@ -489,10 +490,10 @@ FocusScope {
                         launchPS2BIOS.focus = true;
                     }
                     onFocusChanged: container.onFocus(this)
-                    KeyNavigation.down: btnLaunchHongKongBIOS
+                    KeyNavigation.down: btnLaunchAsiaBIOS
                 }
                 SimpleButton {
-                    id: btnLaunchHongKongBIOS
+                    id: btnLaunchAsiaBIOS
                     Rectangle {
                         id: containerValidate
                         width: parent.width
@@ -507,14 +508,14 @@ FocusScope {
                             color: themeColor.textValue
                             font.pixelSize: vpx(30)
                             font.family: globalFonts.ion
-                            text : "\uf2ba  " + qsTr("Launch PS2 BIOS - Hong Kong (to configure)") + api.tr
+                            text : "\uf2ba  " + qsTr("Launch PS2 BIOS - Asia (to configure)") + api.tr
                         }
                     }
                     onActivate: {
                         //to force change of focus
                         launchPS2BIOS.focus = false;
                         launchPS2BIOS.setSource("../../../dialogs/Generic3ChoicesDialog.qml",
-                                                { "title": "PS2 BIOS (Hong Kong)",
+                                                { "title": "PS2 BIOS (Asia)",
                                                   "message": qsTr("Do you want to launch this BIOS now ?") + api.tr,
                                                   "symbol": "\uf412",
                                                   "symbolfont" : global.fonts.ion,
@@ -522,7 +523,7 @@ FocusScope {
                                                   "secondchoice": "",
                                                   "thirdchoice": qsTr("No") + api.tr});
                         //Save region selected for later
-                        region = "china";
+                        region = "asia";
                         //to force change of focus
                         launchPS2BIOS.focus = true;
                     }


### PR DESCRIPTION
	- PS2 features:
		- add overlay support option in menu for Sony PS2 including libretro core and PCSX2 sandalone emulator 
		- add crosshairs option in menu for PCSX2 standalone emulator
		- add split screen hack/fullstretch options in menu for PCSX2 standalone emulator
		- add "GUI at start", "fast boot" and "inject system language in BIOS" from PCSX2 menu
		- add possibility to launch PS2 BIOS from Pegasus menu
		- clarify asia BIOS usage + add more comments
		- add more comment/warning about "fast boot" feature