### PR TITLE
fixes for online update to pixL v1.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file (focus on change done on recalbox-integration branch).
 
-## [pixL-master] - 2025-03-01 - v0.1.10
+## [pixL-master] - 2025-03-16 - v0.1.10
 - Features:
 	- add Amazon Luna controller layout
 	- update ratio Google Stadia
@@ -61,7 +61,11 @@ All notable changes to this project will be documented in this file (focus on ch
 	- fix to change theme loading way
 	- fix to update "previous value" after each changes/saves in video settings
 
-## [pixL-master] - 2025-01.20 - v0.1.8.4
+## [pixL-master] - 2025-03-15 - v0.1.8.5
+- Fixes:
+    - fix download directories for pixL-OS updates (mandatory to upgrade to pixL-OS v1.38)
+
+## [pixL-master] - 2025-01-20 - v0.1.8.4
 - Features:
     - add "pixL patches" repository for updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file (focus on change done on recalbox-integration branch).
 
-## [pixL-master] - 2025-03-16 - v0.1.10
+## [pixL-master] - 2025-03-18- v0.1.10
 - Features:
 	- add Amazon Luna controller layout
 	- update ratio Google Stadia
@@ -61,9 +61,12 @@ All notable changes to this project will be documented in this file (focus on ch
 	- fix to change theme loading way
 	- fix to update "previous value" after each changes/saves in video settings
 
-## [pixL-master] - 2025-03-15 - v0.1.8.5
+## [pixL-master] - 2025-03-18 - v0.1.8.5
 - Fixes:
     - fix download directories for pixL-OS updates (mandatory to upgrade to pixL-OS v1.38)
+    - wait now download asynchronously and launch install script only after
+    - manage dynamically network reply/sender for updates
+    - adding fileIOWriter thread to avoid to be stuck during download/saving of files + cleaning/refactoring
 
 ## [pixL-master] - 2025-01-20 - v0.1.8.4
 - Features:

--- a/src/backend/DownloadManager.cpp
+++ b/src/backend/DownloadManager.cpp
@@ -280,7 +280,8 @@ void DownloadManager::downloadProgress(qint64 bytesReceived, qint64 bytesTotal)
 
     setMessage(QString("%1 ...").arg(output.fileName()));
 
-    setStatus(bytesReceived, bytesTotal);
+    setStatus(static_cast<qint64>(bytesReceived * 0.99), bytesTotal); //-1% just to avoid to be at 100% when download is finish
+                                              // because file could be not saved yet ;-)
 
     // calculate the download speed
     double speed = bytesReceived * 1000.0 / downloadTimer.elapsed();
@@ -301,6 +302,9 @@ void DownloadManager::downloadProgress(qint64 bytesReceived, qint64 bytesTotal)
 
 void DownloadManager::downloadFinished(){
     Log::debug("DownloadManager", LOGMSG("downloadFinished !!!"));
+
+    setSpeed(""); //stop speed
+    setMessage(QString("%1 saving...").arg(output.fileName()));
 
     QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
     if (!reply){

--- a/src/backend/DownloadManager.h
+++ b/src/backend/DownloadManager.h
@@ -83,8 +83,8 @@ private:
     void setSpeed(const QString &m);
     void setStatus(qint64 val, qint64 max);
     void setError(qint64 val);
-    bool isHttpRedirect() const;
-    QUrl reportRedirect();
+    bool isHttpRedirect(QNetworkReply *reply) const;
+    QUrl reportRedirect(QNetworkReply *reply);
 
     QNetworkAccessManager manager;
     QQueue<QUrl> downloadQueue;

--- a/src/backend/DownloadManager.h
+++ b/src/backend/DownloadManager.h
@@ -51,6 +51,7 @@
 
 #include <QtNetwork>
 #include <QtCore>
+#include "FileIOWriter.h"
 
 class DownloadManager: public QObject
 {
@@ -77,6 +78,7 @@ private slots:
     void downloadProgress(qint64 bytesReceived, qint64 bytesTotal);
     void downloadFinished();
     void downloadReadyRead();
+    void writeFinished();
 
 private:
     void setMessage(const QString &m);
@@ -100,5 +102,13 @@ private:
     int iteration = 0;
 
     QString log_tag = "DownloadManager";
+
+    // for file download and write
+    //QFile m_file;
+    //QMutex m_fileMutex;
+    QByteArray m_buffer;
+    FileIOWriter *m_fileWriter = nullptr;
+    //QWaitCondition m_writeFinishedCondition;
+    //qint64 m_pendingWrites = 0;
 
 };

--- a/src/backend/DownloadManager.h
+++ b/src/backend/DownloadManager.h
@@ -48,6 +48,7 @@
 **
 ****************************************************************************/
 //Adapted by BozoTheGeek 29/01/2022
+//Refactored by BozoTheGeek 18/03/2025 (to avoid UI stuck/with a new FileIOWriter class)
 
 #include <QtNetwork>
 #include <QtCore>
@@ -93,7 +94,6 @@ private:
     QQueue<QString> filenameQueue;
     QQueue<qint64> filesizeQueue;
     QNetworkReply *currentDownload = nullptr;
-    QFile output;
     qint64 outputTargetedSize;
     QElapsedTimer downloadTimer;
 
@@ -104,11 +104,7 @@ private:
     QString log_tag = "DownloadManager";
 
     // for file download and write
-    //QFile m_file;
-    //QMutex m_fileMutex;
+    QFile m_file;
     QByteArray m_buffer;
     FileIOWriter *m_fileWriter = nullptr;
-    //QWaitCondition m_writeFinishedCondition;
-    //qint64 m_pendingWrites = 0;
-
 };

--- a/src/backend/FileIOWriter.cpp
+++ b/src/backend/FileIOWriter.cpp
@@ -1,0 +1,48 @@
+#include "FileIOWriter.h"
+//#include "Log.h"
+
+FileIOWriter::FileIOWriter(QFile *file, QObject *parent) : QThread(parent), m_file(file) {}
+
+FileIOWriter::~FileIOWriter() {
+    stop();
+    wait();
+}
+
+void FileIOWriter::writeData(const QByteArray &data) {
+    QMutexLocker locker(&m_mutex);
+    //Log::debug("FileIOWriter::writeData", LOGMSG("data.size(): %1 Bytes").arg(QString::number(data.size())));
+    m_buffer.append(data);
+    m_condition.wakeAll();
+}
+
+void FileIOWriter::stop() {
+    QMutexLocker locker(&m_mutex);
+    m_running = false;
+    m_condition.wakeAll();
+}
+
+void FileIOWriter::run() {
+    while (m_running) {
+        QByteArray dataToWrite;
+        {
+            QMutexLocker locker(&m_mutex);
+            if (m_buffer.isEmpty()) {
+                m_condition.wait(&m_mutex);
+            }
+            if (!m_running && m_buffer.isEmpty()) break; //Check if running is false AND buffer is empty.
+            dataToWrite = m_buffer;
+            m_buffer.clear();
+        }
+        m_file->write(dataToWrite);
+    }
+    // Write any remaining data in the buffer
+    QByteArray remainingData;
+    {
+        QMutexLocker locker(&m_mutex);
+        remainingData = m_buffer;
+    }
+    m_file->write(remainingData);
+    m_file->flush(); //Ensure the data is written to disk.
+    m_file->close();
+    emit finished();
+}

--- a/src/backend/FileIOWriter.h
+++ b/src/backend/FileIOWriter.h
@@ -1,0 +1,32 @@
+#ifndef FILEIOWRITER_H
+#define FILEIOWRITER_H
+
+#include <QThread>
+#include <QFile>
+#include <QMutex>
+#include <QWaitCondition>
+
+class FileIOWriter : public QThread {
+    Q_OBJECT
+
+public:
+    FileIOWriter(QFile *file, QObject *parent = nullptr);
+    ~FileIOWriter();
+    void writeData(const QByteArray &data);
+    void stop();
+
+signals:
+    void finished();
+
+protected:
+    void run() override;
+
+private:
+    QFile *m_file;
+    QMutex m_mutex;
+    QWaitCondition m_condition;
+    QByteArray m_buffer;
+    bool m_running = true;
+};
+
+#endif // FILEIOWRITER_H

--- a/src/backend/backend.pro
+++ b/src/backend/backend.pro
@@ -23,6 +23,7 @@ DEFINES *= HAVE_7ZIP
 SOURCES += \
     Backend.cpp \
     DownloadManager.cpp \
+    FileIOWriter.cpp \
     FrontendLayer.cpp \
     GamepadAxisNavigation.cpp \
     HttpServer.cpp \
@@ -42,6 +43,7 @@ HEADERS += \
     Backend.h \
     CliArgs.h \
     DownloadManager.h \
+    FileIOWriter.h \
     FrontendLayer.h \
     GamepadAxisNavigation.h \
     HttpServer.h \

--- a/src/backend/model/internal/updates/Updates.cpp
+++ b/src/backend/model/internal/updates/Updates.cpp
@@ -514,6 +514,11 @@ void Updates::launchComponentInstallation_slot(QString componentName, const QStr
             //get script content from url
             QString scriptContent;
 
+            //delete log/err files to avoid border effect
+            QFile(directoryPath + "/install.err").remove();
+            QFile(directoryPath + "/install.log").remove();
+            QFile(directoryPath + "/progress.log").remove();
+
             //delete script to avoid problem of existing or corrupted file
             QFile(directoryPath + "/" + versionScriptAsset.m_name_asset).remove();
 

--- a/src/backend/model/internal/updates/Updates.cpp
+++ b/src/backend/model/internal/updates/Updates.cpp
@@ -608,7 +608,7 @@ void Updates::launchComponentInstallation_slot(QString componentName, const QStr
                     }
 
                     //do loop on connect to wait download in this case
-                    m_updates[foundIndex].m_installationStep = 1;
+                    /*m_updates[foundIndex].m_installationStep = 1;
                     QEventLoop loop;
                     QObject::connect(&downloadManager[m_updates[foundIndex].m_downloaderIndex], &DownloadManager::finished, &loop, &QEventLoop::quit);
                     loop.exec();
@@ -616,7 +616,67 @@ void Updates::launchComponentInstallation_slot(QString componentName, const QStr
                     if(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusError > 0){
                         Log::debug(log_tag, LOGMSG("launchComponentInstallation_slot: finished with error - exit status: %1").arg(QString::number(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusError)));
                         return; //exit function now
-                    }
+                    }*/
+
+                    //refactored code
+                    // ... inside your thread ...
+                    m_updates[foundIndex].m_installationStep = 1;
+                    QObject::connect(&downloadManager[m_updates[foundIndex].m_downloaderIndex], &DownloadManager::finished,
+                                     this, [this, foundIndex, existingVersion, newVersion, componentName, diretoryPath, installationScriptAsset]() { // Use a lambda to capture variables
+                                         Log::debug(log_tag, LOGMSG("launchComponentInstallation_slot: %1").arg(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusMessage));
+                                         if (downloadManager[m_updates[foundIndex].m_downloaderIndex].statusError > 0) {
+                                             Log::debug(log_tag, LOGMSG("launchComponentInstallation_slot: finished with error - exit status: %1").arg(QString::number(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusError)));
+                                             // Handle the error (e.g., emit a signal to notify the UI)
+                                             // If neccesary, return from the calling function.
+                                             return;
+                                         }
+                                         // Continue processing after download completion (e.g., installation)
+                                         // ...
+                                         // Example of UI update from non-UI thread
+                                         QMetaObject::invokeMethod(this, [this, foundIndex, existingVersion, newVersion, componentName, diretoryPath, installationScriptAsset]() {
+                                                 // update UI here.
+                                                 Log::debug(log_tag, LOGMSG("launchComponentInstallation_slot: Example of UI update from non-UI thread: %1").arg(QString::number(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusError)));
+                                                 //launch installation after download
+                                                 m_updates[foundIndex].m_installationStep = 2;
+
+                                                 //launch installation script
+                                                 // Build parameters
+                                                 Strings::Vector args;
+                                                 args.push_back("-e");
+                                                 args.push_back(QString(existingVersion).toStdString());
+                                                 args.push_back("-n");
+                                                 args.push_back(QString(newVersion).toStdString());
+                                                 args.push_back("-c");
+                                                 args.push_back(QString(componentName).toStdString());
+
+                                                 //prepare script to run
+                                                 const Path path = Path(QString(diretoryPath + "/" + installationScriptAsset.m_name_asset).toStdString());
+
+                                                 //sync to wait end of script in this slot
+                                                 const ScriptManager::ScriptData script = { path, Notification::None , true };
+                                                 ScriptManagerThread *MyThread = new ScriptManagerThread(script.mPath,args,script.mSync,ScriptManager::Instance().mEnvironment);
+
+                                                 //connect to Thread
+                                                 connect(MyThread, &ScriptManagerThread::finished, [this, foundIndex, componentName](int exit_status)->void{
+                                                     //Check if OK and no error during installation
+                                                     if((exit_status == 0) && (this->getInstallationError(componentName) <= 0)){
+                                                         Log::debug(log_tag, LOGMSG("Thread finished without error - exit status: %1").arg(QString::number(exit_status)));
+                                                         this->m_updates[foundIndex].m_installationStep = 3; //installation finish
+                                                     }
+                                                     else{
+                                                         Log::debug(log_tag, LOGMSG("Thread finished with error - exit status: %1").arg(QString::number(exit_status)));
+                                                         this->m_updates[foundIndex].m_installationStep = 4; //installation finish on error
+                                                     }
+                                                 });
+                                                 MyThread->start();
+                                                 QThread::msleep(200); // sleep temporary to let thread start and show changes else it could crash :-(
+                                             }, Qt::QueuedConnection);
+
+                                     });
+
+                    // Do not block here. The download will happen asynchronously.
+                    // ... continue with other tasks in the thread ...
+                    Log::debug(log_tag, LOGMSG("continue with other tasks in the thread ..."));
                 }
                 else if(installationScriptAsset.m_download_url.startsWith("/",Qt::CaseInsensitive)) //to check if it's a local repo using path
                 {
@@ -626,43 +686,42 @@ void Updates::launchComponentInstallation_slot(QString componentName, const QStr
                     //save script content in a file in /tmp/'Componenet Name' directory
                     saveScript(installationScriptContent, directoryPath + "/" + installationScriptAsset.m_name_asset);
                     //no package downloaded in this case for the moment.
+
+                    //launch installation after download
+                    m_updates[foundIndex].m_installationStep = 2;
+
+                    //launch installation script
+                    // Build parameters
+                    Strings::Vector args;
+                    args.push_back("-e");
+                    args.push_back(QString(existingVersion).toStdString());
+                    args.push_back("-n");
+                    args.push_back(QString(newVersion).toStdString());
+                    args.push_back("-c");
+                    args.push_back(QString(componentName).toStdString());
+
+                    //prepare script to run
+                    const Path path = Path(QString(diretoryPath + "/" + installationScriptAsset.m_name_asset).toStdString());
+
+                    //sync to wait end of script in this slot
+                    const ScriptManager::ScriptData script = { path, Notification::None , true };
+                    ScriptManagerThread *MyThread = new ScriptManagerThread(script.mPath,args,script.mSync,ScriptManager::Instance().mEnvironment);
+
+                    //connect to Thread
+                    connect(MyThread, &ScriptManagerThread::finished, [this, foundIndex, componentName](int exit_status)->void{
+                        //Check if OK and no error during installation
+                        if((exit_status == 0) && (this->getInstallationError(componentName) <= 0)){
+                            Log::debug(log_tag, LOGMSG("Thread finished without error - exit status: %1").arg(QString::number(exit_status)));
+                            this->m_updates[foundIndex].m_installationStep = 3; //installation finish
+                        }
+                        else{
+                            Log::debug(log_tag, LOGMSG("Thread finished with error - exit status: %1").arg(QString::number(exit_status)));
+                            this->m_updates[foundIndex].m_installationStep = 4; //installation finish on error
+                        }
+                    });
+                    MyThread->start();
+                    QThread::msleep(200); // sleep temporary to let thread start and show changes else it could crash :-(
                 }
-
-
-                //launch installation after download
-                m_updates[foundIndex].m_installationStep = 2;
-
-                //launch installation script
-                // Build parameters
-                Strings::Vector args;
-                args.push_back("-e");
-                args.push_back(QString(existingVersion).toStdString());
-                args.push_back("-n");
-                args.push_back(QString(newVersion).toStdString());
-                args.push_back("-c");
-                args.push_back(QString(componentName).toStdString());
-
-                //prepare script to run
-                const Path path = Path(QString(diretoryPath + "/" + installationScriptAsset.m_name_asset).toStdString());
-
-                //sync to wait end of script in this slot
-                const ScriptManager::ScriptData script = { path, Notification::None , true };
-                ScriptManagerThread *MyThread = new ScriptManagerThread(script.mPath,args,script.mSync,ScriptManager::Instance().mEnvironment);
-
-                //connect to Thread
-                connect(MyThread, &ScriptManagerThread::finished, [this, foundIndex, componentName](int exit_status)->void{
-                    //Check if OK and no error during installation
-                    if((exit_status == 0) && (this->getInstallationError(componentName) <= 0)){
-                        Log::debug(log_tag, LOGMSG("Thread finished without error - exit status: %1").arg(QString::number(exit_status)));
-                        this->m_updates[foundIndex].m_installationStep = 3; //installation finish
-                    }
-                    else{
-                        Log::debug(log_tag, LOGMSG("Thread finished with error - exit status: %1").arg(QString::number(exit_status)));
-                        this->m_updates[foundIndex].m_installationStep = 4; //installation finish on error
-                    }
-                });
-                MyThread->start();
-                QThread::msleep(200); // sleep temporary to let thread start and show changes else it could crash :-(
             }
         }
     }

--- a/src/backend/model/internal/updates/Updates.cpp
+++ b/src/backend/model/internal/updates/Updates.cpp
@@ -612,19 +612,7 @@ void Updates::launchComponentInstallation_slot(QString componentName, const QStr
                         else downloadManager[m_updates[foundIndex].m_downloaderIndex].append(QUrl(genericAssets[i].m_download_url),downloaddirectory + "/" + genericAssets[i].m_name_asset); //no set size to always download from 0
                     }
 
-                    //do loop on connect to wait download in this case
-                    /*m_updates[foundIndex].m_installationStep = 1;
-                    QEventLoop loop;
-                    QObject::connect(&downloadManager[m_updates[foundIndex].m_downloaderIndex], &DownloadManager::finished, &loop, &QEventLoop::quit);
-                    loop.exec();
-                    Log::debug(log_tag, LOGMSG("launchComponentInstallation_slot: %1").arg(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusMessage));
-                    if(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusError > 0){
-                        Log::debug(log_tag, LOGMSG("launchComponentInstallation_slot: finished with error - exit status: %1").arg(QString::number(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusError)));
-                        return; //exit function now
-                    }*/
-
                     //refactored code
-                    // ... inside your thread ...
                     m_updates[foundIndex].m_installationStep = 1;
                     QObject::connect(&downloadManager[m_updates[foundIndex].m_downloaderIndex], &DownloadManager::finished,
                                      this, [this, foundIndex, existingVersion, newVersion, componentName, diretoryPath, installationScriptAsset]() { // Use a lambda to capture variables
@@ -636,8 +624,6 @@ void Updates::launchComponentInstallation_slot(QString componentName, const QStr
                                              return;
                                          }
                                          // Continue processing after download completion (e.g., installation)
-                                         // ...
-                                         // Example of UI update from non-UI thread
                                          QMetaObject::invokeMethod(this, [this, foundIndex, existingVersion, newVersion, componentName, diretoryPath, installationScriptAsset]() {
                                                  // update UI here.
                                                  Log::debug(log_tag, LOGMSG("launchComponentInstallation_slot: Example of UI update from non-UI thread: %1").arg(QString::number(downloadManager[m_updates[foundIndex].m_downloaderIndex].statusError)));
@@ -678,10 +664,6 @@ void Updates::launchComponentInstallation_slot(QString componentName, const QStr
                                              }, Qt::QueuedConnection);
 
                                      });
-
-                    // Do not block here. The download will happen asynchronously.
-                    // ... continue with other tasks in the thread ...
-                    Log::debug(log_tag, LOGMSG("continue with other tasks in the thread ..."));
                 }
                 else if(installationScriptAsset.m_download_url.startsWith("/",Qt::CaseInsensitive)) //to check if it's a local repo using path
                 {

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1846,10 +1846,10 @@ Window {
                     isBeta = (api.internal.system.run("grep -i 'beta' /recalbox/recalbox.version") === "") ? false : true
                     isRelease = (api.internal.system.run("grep -i 'release' /recalbox/recalbox.version") === "") ? false : true
                     if(isRelease === true){// to propose release or pre-release in priority
-                        componentsListModel.append({ componentName: "pixL-OS", repoUrl:"https://updates.pixl-os.com/release-pixl-os.json",icon: "qrc:/frontend/assets/logo.png", picture: "qrc:/frontend/assets/backgroundpixl.png", multiVersions: false});
+                        componentsListModel.append({ componentName: "pixL-OS", repoUrl:"https://updates.pixl-os.com/release-pixl-os.json",icon: "qrc:/frontend/assets/logo.png", picture: "qrc:/frontend/assets/backgroundpixl.png", multiVersions: false, downloaddirectory: "/recalbox/share/system/upgrade"});
                     }
                     else if(isBeta === true){ // to propose beta only if we have already a beta version installed
-                        componentsListModel.append({ componentName: "pixL-OS (Beta)", repoUrl:"https://updates.pixl-os.com/beta-pixl-os.json",icon: "qrc:/frontend/assets/logobeta.png", picture: "qrc:/frontend/assets/backgroundpixl.png", multiVersions: false});
+                        componentsListModel.append({ componentName: "pixL-OS (Beta)", repoUrl:"https://updates.pixl-os.com/beta-pixl-os.json",icon: "qrc:/frontend/assets/logobeta.png", picture: "qrc:/frontend/assets/backgroundpixl.png", multiVersions: false, downloaddirectory: "/recalbox/share/system/upgrade"});
                     }
                 }
                 else{// for dev testing only about updates


### PR DESCRIPTION
- Fixes:
    - fix download directories for pixL-OS updates (mandatory to upgrade to pixL-OS v1.38)
    - wait now download asynchronously and launch install script only after
    - manage dynamically network reply/sender for updates
    - adding fileIOWriter thread to avoid to be stuck during download/saving of files + cleaning/refactoring
