### PR TITLE
introduce new "auto emulator/core selection" using rom extensions and priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file (focus on ch
 ## [pixL-master] - 2025-04-XX - v0.1.11
 - Fixes:
 	- open(write/append)file directly in classes for robustness of updates/downloads
+	- deactivate some debug logs
 - Features:
 	- add overlay support for xemu + fix for dolphin
 	- add vsync, scanlines and dsp emulation parameters in XEMU advanced emulator settings
+	- add information on "rom extensions" available by core/emulator in menu
+	- introduce new "auto emulator/core selection" using rom extensions and priorities
+	- add "auto selection" menu navigation and menu visibility management
+	- add feature to find gamelist xml files for a root system and first level of subdirectory
+	- add parameter to activate gamelist(s) search in first level of subdirectories
 
 ## [pixL-master] - 2025-03-18 - v0.1.10
 - Features:

--- a/src/backend/ProcessLauncher.cpp
+++ b/src/backend/ProcessLauncher.cpp
@@ -123,9 +123,9 @@ int getAutoSelectedEmulatorIndex(const model::Game& game)
             }
         }
     }
-    Log::debug(LOGMSG("Emulator/Core Autoselected: '%1/%2'").arg(game.collections().commonEmulators().at(bestEmulatorIndex).name,
-                                                                 game.collections().commonEmulators().at(bestEmulatorIndex).core));
-    Log::debug(LOGMSG("Emulator/Core Autoselected priority: '%1'").arg(bestEmulatorPriority));
+    //Log::debug(LOGMSG("Emulator/Core Autoselected: '%1/%2'").arg(game.collections().commonEmulators().at(bestEmulatorIndex).name,
+    //                                                             game.collections().commonEmulators().at(bestEmulatorIndex).core));
+    //Log::debug(LOGMSG("Emulator/Core Autoselected priority: '%1'").arg(bestEmulatorPriority));
 
     return bestEmulatorIndex;
 }
@@ -246,22 +246,22 @@ void replace_variables(QString& param, const model::GameFile* q_gamefile)
     }
 
     Log::debug(LOGMSG("Emulator/Core configured: '%1/%2'").arg(emulator, core));
-    Log::debug(LOGMSG("Autoselection Parameter: '%1'").arg(QString(shortname + ".autoselection")));
+    //Log::debug(LOGMSG("Autoselection Parameter: '%1'").arg(QString(shortname + ".autoselection")));
     //get info about autoselection if needed
     bool autoselection = RecalboxConf::Instance().AsBool(QString(shortname + ".autoselection").toUtf8().constData());
-    Log::debug(LOGMSG("Autoselection value: '%1'").arg(autoselection));
+    //Log::debug(LOGMSG("Autoselection value: '%1'").arg(autoselection));
     if(autoselection == true){
-        Log::debug(LOGMSG("AutoSelection activated"));
+        //Log::debug(LOGMSG("AutoSelection activated"));
         //get current emulator/core index
         int emulatorIndex = getIndexFromEmulatorCore(game, emulator, core);
         QString suffix = game.filesConst().first()->fileinfo().suffix();
-        Log::debug(LOGMSG("Emulator index identified: '%1'").arg(emulatorIndex));
-        Log::debug(LOGMSG("Suffix identified: '%1'").arg(suffix));
+        //Log::debug(LOGMSG("Emulator index identified: '%1'").arg(emulatorIndex));
+        //Log::debug(LOGMSG("Suffix identified: '%1'").arg(suffix));
         //check if emulator/core is compliant with extension used
         if(!game.collections().commonEmulators().at(emulatorIndex).coreextensions.contains(suffix)){
             //if selected one is not compatible with rom extension, we have to try to find one
             emulatorIndex = getAutoSelectedEmulatorIndex(game);
-            Log::debug(LOGMSG("Emulator index autoselected: '%1'").arg(emulatorIndex));
+            //Log::debug(LOGMSG("Emulator index autoselected: '%1'").arg(emulatorIndex));
             if(emulatorIndex != -1){//if any emulator found by rom extensions and priorities
                 emulator = game.collections().commonEmulators().at(emulatorIndex).name;
                 core = game.collections().commonEmulators().at(emulatorIndex).core;

--- a/src/backend/providers/es2/Es2Metadata.cpp
+++ b/src/backend/providers/es2/Es2Metadata.cpp
@@ -252,25 +252,27 @@ std::vector<QString> Metadata::find_gamelist_xml_files(const QDir& system_dir) c
         found_files.emplace_back(fileInfo.absoluteFilePath());
     }
 
-    // Get the list of first-level subdirectories
-    QFileInfoList first_level_subdirs = system_dir_obj.entryInfoList(
-        QStringList(), // No name filter, we want all directories
-        dir_filters
-        );
+    if(RecalboxConf::Instance().AsBool("pegasus.gamelistinsubdirectories")){
+        // Get the list of first-level subdirectories
+        QFileInfoList first_level_subdirs = system_dir_obj.entryInfoList(
+            QStringList(), // No name filter, we want all directories
+            dir_filters
+            );
 
-    // Iterate through the first-level subdirectories
-    for (const QFileInfo& subdirInfo : first_level_subdirs) {
-        QString subdir_name = subdirInfo.fileName();
-        if (!directories_to_ignore.contains(subdir_name)) {
-            QDir subdir_obj(subdirInfo.absoluteFilePath());
-            QFileInfoList gamelist_in_subdir = subdir_obj.entryInfoList(
-                QStringList() << "gamelist.xml",
-                filters
-                );
+        // Iterate through the first-level subdirectories
+        for (const QFileInfo& subdirInfo : first_level_subdirs) {
+            QString subdir_name = subdirInfo.fileName();
+            if (!directories_to_ignore.contains(subdir_name)) {
+                QDir subdir_obj(subdirInfo.absoluteFilePath());
+                QFileInfoList gamelist_in_subdir = subdir_obj.entryInfoList(
+                    QStringList() << "gamelist.xml",
+                    filters
+                    );
 
-            // Add any found gamelist.xml files from the subdirectory
-            for (const QFileInfo& fileInfo : gamelist_in_subdir) {
-                found_files.emplace_back(fileInfo.absoluteFilePath());
+                // Add any found gamelist.xml files from the subdirectory
+                for (const QFileInfo& fileInfo : gamelist_in_subdir) {
+                    found_files.emplace_back(fileInfo.absoluteFilePath());
+                }
             }
         }
     }

--- a/src/backend/providers/es2/Es2Metadata.h
+++ b/src/backend/providers/es2/Es2Metadata.h
@@ -51,10 +51,11 @@ struct lightgunGameData {
 
 public:
     explicit Metadata(QString, std::vector<QString>);
-    void find_metadata_for_system(const SystemEntry&, const QDir&, providers::SearchContext&) const;
+    size_t find_metadata_for_system(const SystemEntry&, const QDir&, providers::SearchContext&) const;
     void prepare_lightgun_games_metadata();
-    QString find_gamelist_xml(const std::vector<QString>& possible_config_dirs, const QDir& system_dir, const SystemEntry&) const;
-    QString find_media_xml(const std::vector<QString>& possible_config_dirs, const QDir& system_dir, const SystemEntry&) const;
+    QString find_gamelist_xml(const QDir& system_dir, const SystemEntry&) const;
+    std::vector<QString> find_gamelist_xml_files(const QDir& system_dir) const;
+    QString find_media_xml(const QDir& system_dir, const SystemEntry&) const;
 
 private:
     const QString m_log_tag;
@@ -66,7 +67,7 @@ private:
 
     QList <lightgunGameData> m_lightgun_games;
 
-    void process_gamelist_xml(const QDir&, QXmlStreamReader&, providers::SearchContext&, const SystemEntry&) const;
+    void process_gamelist_xml(const QString& gamelist_file_path, providers::SearchContext&, const SystemEntry&) const;
     HashMap<MetaType, QString, EnumHash> parse_gamelist_game_node(QXmlStreamReader&) const;
     void apply_metadata(model::GameFile&, const QDir&, HashMap<MetaType, QString, EnumHash>&, const SystemEntry&) const;
     void add_skraper_media_metadata(const QDir&, providers::SearchContext&, const SystemEntry&, bool generateMediaXML = false) const;

--- a/src/backend/utils/CommandTokenizer.cpp
+++ b/src/backend/utils/CommandTokenizer.cpp
@@ -47,7 +47,7 @@ bool char_is_space(const QChar c) {
 
 
 namespace utils {
-QStringList tokenize_command(const QString& str)
+QStringList tokenize_command(const QString& str, bool take_quote = false)
 {
     QStringList results;
     int o_start = 0;
@@ -72,8 +72,8 @@ QStringList tokenize_command(const QString& str)
         const int len = o_end - o_start;
         const bool starts_with_quote = len > 1 && (char_is_singlequote(ch) || char_is_doublequote(ch));
         const bool fully_quoted = starts_with_quote && (ch == str.at(o_end - 1));
-        const int mid_from = starts_with_quote ? o_start + 1 : o_start;
-        const int mid_len = fully_quoted ? len - 2 : len;
+        const int mid_from = (starts_with_quote & !take_quote) ? o_start + 1 : o_start;
+        const int mid_len = (fully_quoted & !take_quote) ? len - 2 : len;
         results.append(str.midRef(mid_from, mid_len).trimmed().toString());
 
         o_start = o_end;

--- a/src/backend/utils/CommandTokenizer.h
+++ b/src/backend/utils/CommandTokenizer.h
@@ -21,6 +21,6 @@
 
 
 namespace utils {
-QStringList tokenize_command(const QString&);
+QStringList tokenize_command(const QString&, bool);
 QString escape_command(const QString&);
 } // namespace

--- a/src/frontend/menu/settings/InterfaceMain.qml
+++ b/src/frontend/menu/settings/InterfaceMain.qml
@@ -428,6 +428,19 @@ FocusScope {
                         api.internal.recalbox.setBoolParameter("pegasus.mediaondemand",checked);
                     }
                     onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optGamelistInSubDirectories
+                }
+                ToggleOption {
+                    id: optGamelistInSubDirectories
+
+                    label: qsTr("Gamelist in subdirectories") + api.tr
+                    note: qsTr("Once enabled, search 'gamelist.xml' also in first level of subdirectories.\n(Could impact loading performance)") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter("pegasus.gamelistinsubdirectories",false)
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("pegasus.gamelistinsubdirectories",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
                 }
                 Item {
                     width: parent.width

--- a/src/frontend/menu/settings/SystemsEmulatorConfiguration.qml
+++ b/src/frontend/menu/settings/SystemsEmulatorConfiguration.qml
@@ -347,6 +347,7 @@ FocusScope {
                         api.internal.recalbox.setBoolParameter(system.shortName + ".autosave",checked);
                     }
                     onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: emulatorButtons.count > 1 ? optAutoCoreSelection : emulatorButtons.itemAt(0)
                     // not visible if not libretro Core
                     visible : isLibretroCore
                 }
@@ -366,6 +367,7 @@ FocusScope {
                         api.internal.recalbox.setBoolParameter(system.shortName + ".autoselection",checked);
                     }
                     onFocusChanged: container.onFocus(this)
+                    visible: emulatorButtons.count > 1 ? true : false
                 }
 
                 ButtonGroup  { id: radioGroup }
@@ -388,7 +390,7 @@ FocusScope {
                         }
                         
                         onFocusChanged: container.onFocus(this)
-                        KeyNavigation.up: (index !== 0) ?  emulatorButtons.itemAt(index-1) : optSystemAutoSave
+                        KeyNavigation.up: (index !== 0) ?  emulatorButtons.itemAt(index-1) : (emulatorButtons.count > 1) ? optAutoCoreSelection : optSystemAutoSave
                         KeyNavigation.down: (index < emulatorButtons.count) ? emulatorButtons.itemAt(index+1) : emulatorButtons.itemAt(emulatorButtons.count - 1)
                         
                         RadioButton {

--- a/src/frontend/menu/settings/SystemsEmulatorConfiguration.qml
+++ b/src/frontend/menu/settings/SystemsEmulatorConfiguration.qml
@@ -355,7 +355,19 @@ FocusScope {
                     first: true
                     symbol: "\uf179"
                 }
-                
+                ToggleOption {
+                    id: optAutoCoreSelection
+
+                    label: qsTr("Auto emulator/core selection") + api.tr
+                    note: qsTr("To select the best ones to use from rom extensions (if needed)") + api.tr
+
+                    checked: api.internal.recalbox.getBoolParameter(system.shortName + ".autoselection")
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter(system.shortName + ".autoselection",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
+                }
+
                 ButtonGroup  { id: radioGroup }
                 
                 Repeater {

--- a/src/frontend/menu/settings/SystemsEmulatorConfiguration.qml
+++ b/src/frontend/menu/settings/SystemsEmulatorConfiguration.qml
@@ -365,7 +365,8 @@ FocusScope {
                         // system.getCoreAt(index) not visible if not libretro Core for standalone just show emulator name
                         label: system.getNameAt(index) !== system.getCoreAt(index) ? system.getNameAt(index) + " " + system.getCoreAt(index) : system.getNameAt(index) ;
                         // '-' character between long name and version only if version is not empty
-                        note: system.getCoreLongNameAt(index) + ((system.getCoreVersionAt(index) !== "") ? (" - " + system.getCoreVersionAt(index)) : "") ;
+                        note: system.getCoreLongNameAt(index) + ((system.getCoreVersionAt(index) !== "") ? (" - " + system.getCoreVersionAt(index)) : "") + "\n" +
+                              qsTr("rom extensions") + ": " + system.getCoreExtensionsAt(index);
 
                         onActivate: {
                             focus = true;

--- a/tests/backend/utils/test_Utils.cpp
+++ b/tests/backend/utils/test_Utils.cpp
@@ -27,9 +27,6 @@ class test_Utils : public QObject
     Q_OBJECT
 
 private slots:
-    void tokenize_command();
-    void tokenize_command_data();
-
     void escape_command();
     void escape_command_data();
 
@@ -39,31 +36,6 @@ private slots:
     void abspath();
     void abspath_data();
 };
-
-void test_Utils::tokenize_command()
-{
-    QFETCH(QString, str);
-    QFETCH(QStringList, expected);
-
-    QCOMPARE(utils::tokenize_command(str), expected);
-}
-
-void test_Utils::tokenize_command_data()
-{
-    QTest::addColumn<QString>("str");
-    QTest::addColumn<QStringList>("expected");
-
-    QTest::newRow("null") << QString() << QStringList();
-    QTest::newRow("empty") << QString("  \t  ") << QStringList();
-    QTest::newRow("simple") << QString("test a b c") << QStringList({"test","a","b","c"});
-    QTest::newRow("quoted 1") << QString("'test cmd' a 'b c' d") << QStringList({"test cmd","a","b c","d"});
-    QTest::newRow("quoted 2") << QString("\"test cmd\" a \"b c\" d") << QStringList({"test cmd","a","b c","d"});
-    QTest::newRow("quoted 3") << QString("\"test cmd\"\"a b\"'c'") << QStringList({"test cmd","a b", "c"});
-    QTest::newRow("missing quote pair 1") << QString("test 'cmd") << QStringList({"test", "cmd"});
-    QTest::newRow("missing quote pair 2") << QString("test \"cmd") << QStringList({"test", "cmd"});
-    QTest::newRow("in-string quotes") << QString("test'cmd\" a'b  c' d") << QStringList({"test'cmd\"","a'b","c'","d"});
-    QTest::newRow("whitespaces") << QString("  ' test cmd\t'  a\t \"b  c \"  d ") << QStringList({"test cmd","a","b  c","d"});
-}
 
 void test_Utils::escape_command()
 {


### PR DESCRIPTION
	- add information on "rom extensions" available by core/emulator in menu
	- introduce new "auto emulator/core selection" using rom extensions and priorities
	- add "auto selection" menu navigation and menu visibility management
	- add feature to find gamelist xml files for a root system and first level of subdirectory
	- add parameter to activate gamelist(s) search in first level of subdirectories