### PR TITLE
GB Operator support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,23 @@ All notable changes to this project will be documented in this file (focus on ch
 		- skin "human readable" naming management + fix assets loading
 		- skin "name" management + some fixes
 		- add "human readable name" to initial layout also from QML
-		
+	- introduce support of Epilogie GB Operator dumper/reader:
+		- add section for "actions" linked to this reader/dumper
+		- introduction timer for gboperator rom/save management
+		- add settings menu for this dumper/reader
+		- add capacity to hide some usual verbose debug logs
+		- add systemName in "Singleplay" notifications
+		- stable and tested for launch/dump of GB/GBC cartridge
+		- update dumper logs for debug logs
+		- keep header info in romlist csv file
+		- fix sublabel about gboperator.romlist.csv
+		- remove some singleplay debug log
+		- add management of saves
+		- fix extension of dump files
+		- fix to manage game with ' in file name
+		- remove save file writing not supported by retroarch/gboperator for the moment
+		- fix management of saves
+		- add management of dedicated libretro core directory for saves
 	- for dev ;-):
 		- introduction log viewer - first iteration
 	- display Advanced Emulator Settings if emulator present for some cases.

--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -264,11 +264,11 @@ void Backend::start()
     IAudioController::DeviceList playbackList = mAudioController.GetPlaybackList();
     for(const auto& playback : playbackList)
     {
-        Log::debug(LOGMSG("Audio device DisplayableName : '%1'").arg(QString::fromStdString(playback.DisplayableName)));
-        Log::debug(LOGMSG("Audio device InternalName : '%1'").arg(QString::fromStdString(playback.InternalName)));
+        Log::debug(LOGMSG("AudioDevice: DisplayableName - '%1'").arg(QString::fromStdString(playback.DisplayableName)));
+        Log::debug(LOGMSG("AudioDevice: InternalName - '%1'").arg(QString::fromStdString(playback.InternalName)));
         if(playback.InternalName == originalAudioDevice){
             originalAudioDeviceFound = true;
-            Log::debug(LOGMSG("Original Audio Device Found : '%1'").arg(QString::fromStdString(playback.DisplayableName)));
+            Log::debug(LOGMSG("AudioDevice: Original Found - '%1'").arg(QString::fromStdString(playback.DisplayableName)));
             break; //exit for in this case, device found as configured
         }
         else if( QString::fromStdString(playback.DisplayableName).contains("hdmi", Qt::CaseInsensitive) ||

--- a/src/backend/Log.cpp
+++ b/src/backend/Log.cpp
@@ -45,7 +45,16 @@ namespace logsinks {
 class QtLog : public LogSink {
 public:
     void debug(const QString& msg) override {
-        if (RecalboxConf::Instance().AsBool("pegasus.debuglogs")) qDebug().noquote().nospace() << msg;
+        if (RecalboxConf::Instance().AsBool("pegasus.debuglogs")){
+            // 1. Extract everything before the first ':'
+            // section(separator, start, end)
+            // to generate the good parameter
+            const QString parameter = "pegasus.hide." + msg.section(':', 0, 0).trimmed().toLower() + ".debuglogs";
+            // check if parameter is activated to hide this type of debug log
+            if (!RecalboxConf::Instance().AsBool(parameter.toStdString())){
+                qDebug().noquote().nospace() << msg;
+            }
+        }
     }
     void info(const QString& msg) override {
         qInfo().noquote().nospace() << msg;
@@ -65,7 +74,16 @@ public:
         : m_stream(stdout)
     {}
     void debug(const QString& msg) override {
-        if (RecalboxConf::Instance().AsBool("pegasus.debuglogs")) colorlog(m_pre_debug, m_marker_debug, msg);
+        if (RecalboxConf::Instance().AsBool("pegasus.debuglogs")){
+            // 1. Extract everything before the first ':'
+            // section(separator, start, end)
+            // to generate the good parameter
+            const QString parameter = "pegasus.hide." + msg.section(':', 0, 0).trimmed().toLower() + ".debuglogs";
+            // check if parameter is activated to hide this type of debug log
+            if (!RecalboxConf::Instance().AsBool(parameter.toStdString())){
+                colorlog(m_pre_debug, m_marker_debug, msg);
+            }
+        }
     }
     void info(const QString& msg) override {
         colorlog(m_pre_info, m_marker_info, msg);
@@ -138,7 +156,16 @@ public:
         if (Q_UNLIKELY(!m_file.isOpen()))
             return;
 
-        if (RecalboxConf::Instance().AsBool("pegasus.debuglogs")) datelog(m_marker_debug, msg);
+        if (RecalboxConf::Instance().AsBool("pegasus.debuglogs")){
+            // 1. Extract everything before the first ':'
+            // section(separator, start, end)
+            // to generate the good parameter
+            const QString parameter = "pegasus.hide." + msg.section(':', 0, 0).trimmed().toLower() + ".debuglogs";
+            // check if parameter is activated to hide this type of debug log
+            if (!RecalboxConf::Instance().AsBool(parameter.toStdString())){
+                datelog(m_marker_debug, msg);
+            }
+        }
     }
     void info(const QString& msg) override {
         if (Q_UNLIKELY(!m_file.isOpen()))
@@ -233,7 +260,16 @@ void on_qt_message(QtMsgType type, const QMessageLogContext& context, const QStr
     const QString prepared_msg = qFormatLogMessage(type, context, msg);
     switch (type) {
         case QtMsgType::QtDebugMsg:
-            if (RecalboxConf::Instance().AsBool("pegasus.debuglogs")) Log::debug(prepared_msg);
+            if (RecalboxConf::Instance().AsBool("pegasus.debuglogs")){
+                // 1. Extract everything before the first ':'
+                // section(separator, start, end)
+                // to generate the good parameter
+                const QString parameter = "pegasus.hide." + msg.section(':', 0, 0).trimmed().toLower() + ".debuglogs";
+                // check if parameter is activated to hide this type of debug log
+                if (!RecalboxConf::Instance().AsBool(parameter.toStdString())){
+                    Log::debug(prepared_msg);
+                }
+            }
             break;
         case QtMsgType::QtInfoMsg:
             Log::info(prepared_msg);

--- a/src/backend/ProcessLauncher.cpp
+++ b/src/backend/ProcessLauncher.cpp
@@ -403,7 +403,7 @@ ProcessLauncher::ProcessLauncher(QObject* parent)
 
 void ProcessLauncher::onLaunchRequested(const model::GameFile* q_gamefile)
 {
-    //Log::debug(LOGMSG("void ProcessLauncher::onLaunchRequested(const model::GameFile* q_gamefile)"));
+    Log::debug(LOGMSG("void ProcessLauncher::onLaunchRequested(const model::GameFile* q_gamefile)"));
     Q_ASSERT(q_gamefile);
     //Log::debug(LOGMSG("Q_ASSERT(q_gamefile);"));
 

--- a/src/backend/ScriptManager.cpp
+++ b/src/backend/ScriptManager.cpp
@@ -215,9 +215,10 @@ void ScriptManager::BuildStateCommons(std::string& output, const model::Collecti
         .append("ActionData=").append(actionParameters).append(eol);
 
   // System
-  if (game != nullptr)
-      output.append("System=").append(game->collections().name().toUtf8().constData()).append(eol)
-          .append("SystemId=").append(game->systemShortName().toUtf8().constData()).append(eol);
+  if (game != nullptr){
+      output.append("System=").append(game->systemName().toUtf8().constData()).append(eol);
+      output.append("SystemId=").append(game->systemShortName().toUtf8().constData()).append(eol);
+  }
   else if (collection != nullptr)
       output.append("System=").append(collection->name().toUtf8().constData()).append(eol)
           .append("SystemId=").append(collection->shortName().toUtf8().constData()).append(eol);

--- a/src/backend/ScriptManager.cpp
+++ b/src/backend/ScriptManager.cpp
@@ -163,12 +163,12 @@ void ScriptManager::LoadScriptList()
         if (permanent)
         {
           RunProcess(path, {}, false, true);
-          { LOG(LogDebug) << "[Script] Run permanent UserScript: " << path.ToString(); }
+          { LOG(LogDebug) << "Scripts: Run permanent UserScript - " << path.ToString(); }
         }
         else
         {
           mScriptList.push_back({ path, ExtractNotificationsFromPath(path), synced });
-          { LOG(LogDebug) << "[Script] Scan UserScript: " << path.ToString(); }
+          { LOG(LogDebug) << "Scripts: Scan UserScript - " << path.ToString(); }
         }
       }
 }
@@ -370,7 +370,7 @@ void ScriptManager::RunProcess(const Path& target, const Strings::Vector& argume
   args.push_back(target.ToChars());
   for (const std::string& argument : arguments) args.push_back(argument.c_str());
 
-  { LOG(LogDebug) << "[Script] Run UserScript: " << Strings::Join(args, ' '); }
+  { LOG(LogDebug) << "Scripts: Run UserScript - " << Strings::Join(args, ' '); }
 
   // Push final null
   args.push_back(nullptr);
@@ -450,12 +450,12 @@ std::string ScriptManager::RunProcessWithReturn(const Path& target, const String
   args.push_back(target.ToChars());
   for (const std::string& argument : arguments) args.push_back(argument.c_str());
 
-  { LOG(LogDebug) << "[Script] Run UserScript: " << Strings::Join(args, ' '); }
-  { LOG(LogDebug) << "[Script] Run UserScript (command): " << command.data(); }
-  { LOG(LogDebug) << "[Script] Run UserScript (args): " << args.data(); }
+  { LOG(LogDebug) << "Scripts: Run UserScript - " << Strings::Join(args, ' '); }
+  { LOG(LogDebug) << "Scripts: Run UserScript (command) - " << command.data(); }
+  { LOG(LogDebug) << "Scripts: Run UserScript (args) - " << args.data(); }
 
   std::string result = run(Strings::Join(args, ' '));
-  { LOG(LogDebug) << "[Script] UserScript return: " << result; }
+  { LOG(LogDebug) << "Scripts: UserScript return - " << result; }
   // Push final null
   args.push_back(nullptr);
   return result;

--- a/src/backend/audio/pulseaudio/PulseAudioController.cpp
+++ b/src/backend/audio/pulseaudio/PulseAudioController.cpp
@@ -36,7 +36,7 @@ void PulseAudioController::Initialize()
 
   // Subscribe to changes
   //PulseSubscribe();
-  { LOG(LogDebug) << "[PulseAudio] Initialized."; }
+  { LOG(LogDebug) << "PulseAudio: Initialized."; }
 }
 
 void PulseAudioController::Finalize()
@@ -49,7 +49,7 @@ void PulseAudioController::SetProfileCallback(pa_context *context, int success, 
   (void)context;
   (void)success;
 
-  { LOG(LogDebug) << "[PulseAudio] Set Profile result: " << (success != 0 ? "SUCCESS" : "FAIL"); }
+  { LOG(LogDebug) << "PulseAudio: Set Profile result: " << (success != 0 ? "SUCCESS" : "FAIL"); }
 
   // Get class
   PulseAudioController& This = *(PulseAudioController*)userdata;
@@ -63,7 +63,7 @@ void PulseAudioController::SetVolumeCallback(pa_context *context, int success, v
   (void)context;
   (void)success;
 
-  { LOG(LogDebug) << "[PulseAudio] Set Volume result: " << (success != 0 ? "SUCCESS" : "FAIL"); }
+  { LOG(LogDebug) << "PulseAudio: Set Volume result: " << (success != 0 ? "SUCCESS" : "FAIL"); }
 
   // Get class
   PulseAudioController& This = *(PulseAudioController*)userdata;
@@ -77,7 +77,7 @@ void PulseAudioController::SetMuteCallback(pa_context *context, int success, voi
   (void)context;
   (void)success;
 
-  { LOG(LogDebug) << "[PulseAudio] Set Mute result: " << (success != 0 ? "SUCCESS" : "FAIL"); }
+  { LOG(LogDebug) << "PulseAudio: Set Mute result: " << (success != 0 ? "SUCCESS" : "FAIL"); }
 
   // Get class
   PulseAudioController& This = *(PulseAudioController*)userdata;
@@ -91,7 +91,7 @@ void PulseAudioController::SetSinkCallback(pa_context *context, int success, voi
   (void)context;
   (void)success;
 
-  { LOG(LogDebug) << "[PulseAudio] Set Sink result: " << (success != 0 ? "SUCCESS" : "FAIL"); }
+  { LOG(LogDebug) << "PulseAudio: Set Sink result: " << (success != 0 ? "SUCCESS" : "FAIL"); }
 
   // Get class
   PulseAudioController& This = *(PulseAudioController*)userdata;
@@ -105,7 +105,7 @@ void PulseAudioController::SetPortCallback(pa_context *context, int success, voi
   (void)context;
   (void)success;
 
-  { LOG(LogDebug) << "[PulseAudio] Set Port result: " << (success != 0 ? "SUCCESS" : "FAIL"); }
+  { LOG(LogDebug) << "PulseAudio: Set Port result: " << (success != 0 ? "SUCCESS" : "FAIL"); }
 
   // Get class
   PulseAudioController& This = *(PulseAudioController*)userdata;
@@ -178,7 +178,7 @@ void PulseAudioController::SubsciptionCallback(pa_context *context, pa_subscript
     default: eventStr = "UNKNOWN EVENT"; break;
   }
 
-  { LOG(LogError) << "[PulseAudio] EVENT! Type: " << typeStr << " - Event: " << eventStr << " - Index: " << index; }
+  { LOG(LogError) << "PulseAudio: EVENT! Type: " << typeStr << " - Event: " << eventStr << " - Index: " << index; }
 }
 
 AudioIcon PulseAudioController::GetPortIcon(const pa_card_port_info& info)
@@ -213,14 +213,14 @@ void PulseAudioController::EnumerateCardCallback(pa_context* context, const pa_c
   newCard.Index = info->index;
   newCard.HasActioveProfile = false;
 
-  { LOG(LogDebug) << "[PulseAudio] Card #" << newCard.Index << " : " << newCard.Name; }
+  { LOG(LogDebug) << "PulseAudio: Card #" << newCard.Index << " : " << newCard.Name; }
 
   // Active profile
   std::string activeProfileName;
   if (info->active_profile2 != nullptr)
   {
     activeProfileName = info->active_profile2->name;
-    { LOG(LogDebug) << "[PulseAudio] Active Profile: " << info->active_profile2->description << " ("
+    { LOG(LogDebug) << "PulseAudio: Active Profile: " << info->active_profile2->description << " ("
                     << info->active_profile2->name << ") - Available "
                     << (info->active_profile2->available != 0 ? "YES" : "NO") << " - Priority "
                     << info->active_profile2->priority; }
@@ -240,7 +240,7 @@ void PulseAudioController::EnumerateCardCallback(pa_context* context, const pa_c
     newPort.Priority = portInfo.priority;
     newPort.InternalIndex = (int)newCard.Ports.size();
 
-    { LOG(LogDebug) << "[PulseAudio]   Port " << newPort.Description << " (" << newPort.Name << ") - Available " << (newPort.Available ? "YES" : "NO") << " - Priority " << newPort.Priority; }
+    { LOG(LogDebug) << "PulseAudio:   Port " << newPort.Description << " (" << newPort.Name << ") - Available " << (newPort.Available ? "YES" : "NO") << " - Priority " << newPort.Priority; }
 
     // Port's supported profiles
     for(int p = portInfo.n_profiles; --p >= 0; )
@@ -254,7 +254,7 @@ void PulseAudioController::EnumerateCardCallback(pa_context* context, const pa_c
       newProfile.Available = profileInfo.available != 0;
       newProfile.Priority = profileInfo.priority;
 
-      { LOG(LogDebug) << "[PulseAudio]     Profile " << newProfile.Description << " (" << newProfile.Name << ") - Available " << (newProfile.Available ? "YES" : "NO") << " - Priority " << newProfile.Priority; }
+      { LOG(LogDebug) << "PulseAudio:     Profile " << newProfile.Description << " (" << newProfile.Name << ") - Available " << (newProfile.Available ? "YES" : "NO") << " - Priority " << newProfile.Priority; }
 
       // Check if this profile is the active one
       newCard.HasActioveProfile |= (newProfile.Name == activeProfileName);
@@ -291,13 +291,13 @@ void PulseAudioController::EnumerateSinkCallback(pa_context* context, const pa_s
   newSink.Index = info->index;
   newSink.Channels = info->channel_map.channels;
 
-  { LOG(LogDebug) << "[PulseAudio] Sink #" << newSink.Index << ' ' << newSink.Name << " found."; }
+  { LOG(LogDebug) << "PulseAudio: Sink #" << newSink.Index << ' ' << newSink.Name << " found."; }
 
   // Collect available ports
   for(int i = info->n_ports; --i >= 0; )
   {
     newSink.PortNames.push_back(info->ports[i]->name);
-    { LOG(LogDebug) << "[PulseAudio]   Port " << info->ports[i]->name << " - " << info->ports[i]->description; }
+    { LOG(LogDebug) << "PulseAudio:   Port " << info->ports[i]->name << " - " << info->ports[i]->description; }
   }
 
   // Attach the sink to it's parent card
@@ -309,12 +309,12 @@ void PulseAudioController::EnumerateSinkCallback(pa_context* context, const pa_s
       card.Sinks.push_back(newSink);
       This.mSyncer.UnLock();
       attached = true;
-      { LOG(LogDebug) << "[PulseAudio] Sink #" << newSink.Index << ' ' << newSink.Name << " attached to card #" << card.Index << ' ' << card.Name; }
+      { LOG(LogDebug) << "PulseAudio: Sink #" << newSink.Index << ' ' << newSink.Name << " attached to card #" << card.Index << ' ' << card.Name; }
     }
 
   // Attached?
   if (!attached)
-  { LOG(LogWarning) << "[PulseAudio] Sink #" << newSink.Index << ' ' << newSink.Name << " has no parent card!"; }
+  { LOG(LogWarning) << "PulseAudio: Sink #" << newSink.Index << ' ' << newSink.Name << " has no parent card!"; }
 }
 
 void PulseAudioController::AddSpecialPlaybacks(IAudioController::DeviceList& list)
@@ -438,24 +438,24 @@ std::string PulseAudioController::SetDefaultPlayback(const std::string& original
   {
     Mutex::AutoLock lock(mSyncer);
 
-    { LOG(LogDebug) << "[PulseAudio] Switching to " << playbackName; }
+    { LOG(LogDebug) << "PulseAudio: Switching to " << playbackName; }
 
     std::string cardName;
     std::string portName;
     if (!Strings::SplitAt(playbackName, ':', cardName, portName, true))
-    { LOG(LogError) << "[PulseAudio] Invalid playbackname: " << playbackName; }
+    { LOG(LogError) << "PulseAudio: Invalid playbackname: " << playbackName; }
 
     card = LookupCard(cardName);
-    if (card == nullptr) { LOG(LogError) << "[PulseAudio] No sound card available!"; return playbackName; }
+    if (card == nullptr) { LOG(LogError) << "PulseAudio: No sound card available!"; return playbackName; }
     port = LookupPort(*card, portName);
-    if (port == nullptr) { LOG(LogError) << "[PulseAudio] No port '" << portName << "' available on sound card " << card->Description; return playbackName; }
+    if (port == nullptr) { LOG(LogError) << "PulseAudio: No port '" << portName << "' available on sound card " << card->Description; return playbackName; }
 
     // Activate port's best profile
     const Profile* selectedProfile = &port->Profiles[0];
     for (const Profile& profile : port->Profiles)
       selectedProfile = (profile.Priority > selectedProfile->Priority) ? &profile : selectedProfile;
 
-    { LOG(LogDebug) << "[PulseAudio] Activating profile " << selectedProfile->Description << " for card #" << card->Index << ' ' << card->Name; }
+    { LOG(LogDebug) << "PulseAudio: Activating profile " << selectedProfile->Description << " for card #" << card->Index << ' ' << card->Name; }
 
     pa_operation* profileOp = pa_context_set_card_profile_by_index(mPulseAudioContext, card->Index, selectedProfile->Name.data(), SetProfileCallback,this);
     // Wait for response
@@ -478,7 +478,7 @@ std::string PulseAudioController::SetDefaultPlayback(const std::string& original
     mSignal.WaitSignal();
     // Release
     pa_operation_unref(op);
-    { LOG(LogDebug) << "[PulseAudio] Sink '" << sink.Name << "' has been switched to port " << port->Name; }
+    { LOG(LogDebug) << "PulseAudio: Sink '" << sink.Name << "' has been switched to port " << port->Name; }
 
     // Set sink the default one
     op = pa_context_set_default_sink(mPulseAudioContext, sink.Name.data(), SetSinkCallback, this);
@@ -486,7 +486,7 @@ std::string PulseAudioController::SetDefaultPlayback(const std::string& original
     mSignal.WaitSignal();
     // Release
     pa_operation_unref(op);
-    { LOG(LogDebug) << "[PulseAudio] Sink '" << sink.Name << "' has been set as default sink."; }
+    { LOG(LogDebug) << "PulseAudio: Sink '" << sink.Name << "' has been set as default sink."; }
 
     break;
   }
@@ -554,14 +554,14 @@ void PulseAudioController::PulseContextConnect()
 {
   // Wait for response
   mSignal.WaitSignal();
-  { LOG(LogDebug) << "[PulseAudio] Connected to Server."; }
+  { LOG(LogDebug) << "PulseAudio: Connected to Server."; }
 }
 
 void PulseAudioController::PulseContextDisconnect()
 {
   // Disconnect from pulse server
   pa_context_disconnect(mPulseAudioContext);
-  { LOG(LogDebug) << "[PulseAudio] Disconnected to Server."; }
+  { LOG(LogDebug) << "PulseAudio: Disconnected to Server."; }
 }
 
 void PulseAudioController::PulseEnumarateSinks()
@@ -572,7 +572,7 @@ void PulseAudioController::PulseEnumarateSinks()
   mSyncer.UnLock();
 
   // Enumerate sinks
-  { LOG(LogDebug) << "[PulseAudio] Enumerating Sinks"; }
+  { LOG(LogDebug) << "PulseAudio: Enumerating Sinks"; }
   pa_operation* sinkOp = pa_context_get_sink_info_list(mPulseAudioContext, EnumerateSinkCallback, this);
   // Wait for response
   mSignal.WaitSignal();
@@ -583,7 +583,7 @@ void PulseAudioController::PulseEnumarateSinks()
   for(Card& card : mCards)
     for(Sink& sink : card.Sinks)
     {
-      { LOG(LogDebug) << "[PulseAudio] Unmute Sink #" << sink.Index << " - " << sink.Name; }
+      { LOG(LogDebug) << "PulseAudio: Unmute Sink #" << sink.Index << " - " << sink.Name; }
       // Set volume
       pa_context_set_sink_mute_by_index(mPulseAudioContext, sink.Index, 0, SetMuteCallback, this);
       // Wait for result
@@ -611,10 +611,10 @@ const PulseAudioController::Profile* PulseAudioController::GetBestProfile(const 
   }
   // Check port
   if (selectedPort == nullptr)
-  { LOG(LogWarning) << "[PulseAudio] Card #" << card.Index << ' ' << card.Name << " has no port with available profiles!"; return nullptr; }
+  { LOG(LogWarning) << "PulseAudio: Card #" << card.Index << ' ' << card.Name << " has no port with available profiles!"; return nullptr; }
 
   // Check available profiles
-  if (selectedPort->Profiles.empty()) { LOG(LogWarning) << "[PulseAudio] Card #" << card.Index << ' ' << card.Name << ", Port " << selectedPort->Description << " has no profile!"; return nullptr; }
+  if (selectedPort->Profiles.empty()) { LOG(LogWarning) << "PulseAudio: Card #" << card.Index << ' ' << card.Name << ", Port " << selectedPort->Description << " has no profile!"; return nullptr; }
 
   // Seek for the highest profile
   const Profile* selectedProfile = &selectedPort->Profiles[0];
@@ -629,15 +629,15 @@ void PulseAudioController::SetDefaultProfiles()
   for(Card& card : mCards)
   {
     if (card.HasActioveProfile) continue;
-    if (card.Ports.empty()) { LOG(LogWarning) << "[PulseAudio] Card #" << card.Index << ' ' << card.Name << " has no port!"; continue; }
+    if (card.Ports.empty()) { LOG(LogWarning) << "PulseAudio: Card #" << card.Index << ' ' << card.Name << " has no port!"; continue; }
 
-    { LOG(LogDebug) << "[PulseAudio] Card #" << card.Index << ' ' << card.Name << " has no profile activated."; }
+    { LOG(LogDebug) << "PulseAudio: Card #" << card.Index << ' ' << card.Name << " has no profile activated."; }
 
     const Profile* selectedProfile = GetBestProfile(card);
     if (selectedProfile == nullptr) continue;
 
     // Activate selected profile
-    { LOG(LogDebug) << "[PulseAudio] Activating profile " << selectedProfile->Description << " for card #" << card.Index << ' ' << card.Name; }
+    { LOG(LogDebug) << "PulseAudio: Activating profile " << selectedProfile->Description << " for card #" << card.Index << ' ' << card.Name; }
 
     pa_operation* profileOp = pa_context_set_card_profile_by_index(mPulseAudioContext, card.Index, selectedProfile->Name.data(), SetProfileCallback, this);
     // Wait for response
@@ -652,7 +652,7 @@ void PulseAudioController::PulseEnumerateCards()
   mCards.clear();
 
   // Enumerate cards
-  { LOG(LogDebug) << "[PulseAudio] Enumerating Cards."; }
+  { LOG(LogDebug) << "PulseAudio: Enumerating Cards."; }
   pa_operation* cardOp = pa_context_get_card_info_list(mPulseAudioContext, EnumerateCardCallback, this);
   
   // Wait for response
@@ -671,7 +671,7 @@ void PulseAudioController::PulseEnumerateCards()
 
 void PulseAudioController::PulseSubscribe()
 {
-  { LOG(LogDebug) << "[PulseAudio] Subscribing to events"; }
+  { LOG(LogDebug) << "PulseAudio: Subscribing to events"; }
 
   pa_context_set_subscribe_callback(mPulseAudioContext, SubsciptionCallback, this);
   pa_context_subscribe(mPulseAudioContext, PA_SUBSCRIPTION_MASK_ALL, nullptr, nullptr);

--- a/src/backend/model/gaming/Game.cpp
+++ b/src/backend/model/gaming/Game.cpp
@@ -36,7 +36,7 @@ QString joined_list(const QStringList& list) { return list.join(QLatin1String(",
 
 namespace model {
 
-const providers::retroAchievements::Metadata Game::m_metahelper("Game retroachievements");
+const providers::retroAchievements::Metadata Game::m_metahelper("retroachievements");
 
 GameData::GameData() = default;
 

--- a/src/backend/model/gaming/Game.h
+++ b/src/backend/model/gaming/Game.h
@@ -91,6 +91,7 @@ struct GameData {
     QString launchCmdBasedir = "";
     QString systemManufacturer = "";
     QString systemShortName = "";
+    QString systemName = "";
     QString emulatorName = "";
     QString emulatorCore = "";
 };
@@ -146,6 +147,12 @@ public:
         else return m_data.systemShortName;
     }
     //new way to provide launch command to be able to manage with single play
+    const QString& systemName() const {
+        //Log::debug(LOGMSG("Game::m_data.systemName : %1").arg(m_data.systemName));
+        if (m_data.systemName == "") return m_collections->get(0)->name();
+        else return m_data.systemName;
+    }
+    //new way to provide launch command to be able to manage with single play
     const QString& launchCmd() const {
         //Log::debug(LOGMSG("Game::m_data.launchCmd : %1").arg(m_data.launchCmd));
         if (m_data.launchCmd == "") return m_collections->get(0)->commonLaunchCmd();
@@ -192,6 +199,7 @@ public:
     SETTER(QString, LaunchCmdBasedir, launchCmdBasedir)
     SETTER(QString, SystemManufacturer, systemManufacturer)
     SETTER(QString, SystemShortName, systemShortName)
+    SETTER(QString, SystemName, systemName)
     SETTER(QString, EmulatorName, emulatorName)
     SETTER(QString, EmulatorCore, emulatorCore)
 

--- a/src/backend/model/internal/settings/ParametersList.cpp
+++ b/src/backend/model/internal/settings/ParametersList.cpp
@@ -913,10 +913,10 @@ QStringList GetParametersList(QString Parameter)
 
         for(const auto& playback : playbackList)
         {
-          //Log::debug(LOGMSG("Audio device DisplayableName : '%1'").arg(QString::fromStdString(playback.DisplayableName)));
+          //Log::debug(LOGMSG("AudioDevice: DisplayableName - '%1'").arg(QString::fromStdString(playback.DisplayableName)));
             ListOfValue.append(QString::fromStdString(playback.DisplayableName)); // using Awesome Web Font
 
-          //Log::debug(LOGMSG("Audio device InternalName : '%1'").arg(QString::fromStdString(playback.InternalName)));
+          //Log::debug(LOGMSG("AudioDevice: InternalName - '%1'").arg(QString::fromStdString(playback.InternalName)));
             ListOfInternalValue.append(QString::fromStdString(playback.InternalName));
         }
         if(ListOfValue.isEmpty())
@@ -1301,10 +1301,10 @@ QStringList GetParametersList(QString Parameter)
 
         for(const auto& playback : playbackList)
         {
-          //Log::debug(LOGMSG("Audio device DisplayableName : '%1'").arg(QString::fromStdString(playback.DisplayableName)));
+          //Log::debug(LOGMSG("AudioDevice: DisplayableName - '%1'").arg(QString::fromStdString(playback.DisplayableName)));
             ListOfValue.append(QString::fromStdString(playback.DisplayableName)); // using Awesome Web Font
 
-          //Log::debug(LOGMSG("Audio device InternalName : '%1'").arg(QString::fromStdString(playback.InternalName)));
+          //Log::debug(LOGMSG("AudioDevice: InternalName - '%1'").arg(QString::fromStdString(playback.InternalName)));
             ListOfInternalValue.append(QString::fromStdString(playback.InternalName));
         }
         if(ListOfValue.isEmpty())

--- a/src/backend/model/internal/singleplay/Singleplay.cpp
+++ b/src/backend/model/internal/singleplay/Singleplay.cpp
@@ -32,7 +32,8 @@ void Singleplay::setSystem (const QString shortName){
             .setLaunchWorkdir("/recalbox/share/roms/" + sysentry.shortname)
             .setLaunchCmdBasedir(" ")
             .setSystemManufacturer(sysentry.manufacturer)
-            .setSystemShortName(sysentry.shortname);
+            .setSystemShortName(sysentry.shortname)
+            .setSystemName(sysentry.name);
         //To take into account priority=1 (or lower value) as default emulator and core
         int first_priority = 0;
         for (int n = 0;n < sysentry.emulators.count(); n++)

--- a/src/backend/model/internal/singleplay/Singleplay.cpp
+++ b/src/backend/model/internal/singleplay/Singleplay.cpp
@@ -20,9 +20,9 @@ Singleplay::Singleplay(QObject* parent)
 }
 
 void Singleplay::setSystem (const QString shortName){
-    //Log::debug(LOGMSG("shortName : %1").arg(shortName));
+    Log::debug(LOGMSG("shortName : %1").arg(shortName));
     providers::es2::SystemEntry sysentry = Provider->find_one_system(shortName);
-    //Log::debug(LOGMSG("sysentry.shortname : %1").arg(sysentry.shortname));
+    Log::debug(LOGMSG("sysentry.shortname : %1").arg(sysentry.shortname));
 
     //Way added to manage a game without collection
      if(sysentry.shortname == shortName){ //system found

--- a/src/backend/model/internal/singleplay/Singleplay.cpp
+++ b/src/backend/model/internal/singleplay/Singleplay.cpp
@@ -56,4 +56,38 @@ void Singleplay::setSystem (const QString shortName){
     }
 }
 
+//needed to know where to store the "save/ram" file using libretro (retroarch)
+Q_INVOKABLE QString Singleplay::getEmulatorName(){
+    return m_game.emulatorName();
+}
+
+//needed to know where to store the "save/ram" file using retroarch
+Q_INVOKABLE QString Singleplay::getCoreLongName(){
+    //Log::debug(LOGMSG("shortName : %1").arg(m_game.systemShortName()));
+    providers::es2::SystemEntry sysentry = Provider->find_one_system(m_game.systemShortName());
+    //Log::debug(LOGMSG("sysentry.shortname : %1").arg(sysentry.shortname));
+
+    //Way added to manage a game without collection
+    QString CoreLongName = "";
+    if(sysentry.shortname == m_game.systemShortName()){ //system found
+        //To take into account priority=1 (or lower value) as default emulator and core
+        int first_priority = 0;
+        for (int n = 0;n < sysentry.emulators.count(); n++)
+        {
+            //if only one or to initialize with one value
+            if (n == 0)
+            {
+                first_priority = sysentry.emulators[n].priority;
+                CoreLongName = sysentry.emulators[n].corelongname;
+            }
+            else if(first_priority > sysentry.emulators[n].priority) //else we check if previous priority is lower (but number is higher ;-)
+            {
+                first_priority = sysentry.emulators[n].priority;
+                CoreLongName = sysentry.emulators[n].corelongname;
+            }
+        }
+    }
+    return CoreLongName;
+}
+
 } // namespace model

--- a/src/backend/model/internal/singleplay/Singleplay.cpp
+++ b/src/backend/model/internal/singleplay/Singleplay.cpp
@@ -20,9 +20,9 @@ Singleplay::Singleplay(QObject* parent)
 }
 
 void Singleplay::setSystem (const QString shortName){
-    Log::debug(LOGMSG("shortName : %1").arg(shortName));
+    //Log::debug(LOGMSG("shortName : %1").arg(shortName));
     providers::es2::SystemEntry sysentry = Provider->find_one_system(shortName);
-    Log::debug(LOGMSG("sysentry.shortname : %1").arg(sysentry.shortname));
+    //Log::debug(LOGMSG("sysentry.shortname : %1").arg(sysentry.shortname));
 
     //Way added to manage a game without collection
      if(sysentry.shortname == shortName){ //system found

--- a/src/backend/model/internal/singleplay/Singleplay.h
+++ b/src/backend/model/internal/singleplay/Singleplay.h
@@ -30,6 +30,8 @@ public:
         m_game.setPath(path);
     }
     Q_INVOKABLE void setSystem (const QString shortName);
+    Q_INVOKABLE QString getEmulatorName(); //needed to know where to store the "save/ram" file using libretro (retroarch)
+    Q_INVOKABLE QString getCoreLongName(); //needed to know where to store the "save/ram" file using retroarch
 
 signals:
 

--- a/src/backend/providers/retroachievements/RetroAchievementsMetadata.cpp
+++ b/src/backend/providers/retroachievements/RetroAchievementsMetadata.cpp
@@ -471,8 +471,8 @@ QString get_token_from_cache(QString log_tag, QString json_cache_dir)
 	Password.remove("\\", Qt::CaseInsensitive);
 	
     //Try to get token from json in cache
-    QJsonDocument json = providers::read_json_from_cache(log_tag + " - cache", json_cache_dir, hashQString(Username + Password));
-    QString token = apply_login_json(log_tag + " - cache", json);
+    QJsonDocument json = providers::read_json_from_cache(log_tag, json_cache_dir, hashQString(Username + Password));
+    QString token = apply_login_json(log_tag, json);
     if(token == ""){
         //Delete JSON in cache by security - use Username and Password to have a unique key and if password is changed finally.
         providers::delete_cached_json(log_tag, json_cache_dir, hashQString(Username + Password));
@@ -582,13 +582,13 @@ bool get_game_details_from_gameid(int gameid, QString token, model::Game& game, 
 	if (gameid != 0)
 	{
 		//Try to get game details from json in cache
-		QJsonDocument json = providers::read_json_from_cache(log_tag + " - cache", json_cache_dir, "RaGameID=" + QString::number(gameid));
-		result = apply_game_json(game, log_tag + " - cache", json);
+        QJsonDocument json = providers::read_json_from_cache(log_tag, json_cache_dir, "RaGameID=" + QString::number(gameid));
+        result = apply_game_json(game, log_tag, json);
         Log::debug(log_tag, LOGMSG("get_game_details_from_gameid - Json cache for Game: '%1' - RaGameID '%2' found: '%3'").arg(game.title(),QString::number(gameid), QString::number(result)));
         if (result == false)
 		{
 			//Delete JSON inb cache by security - use Username and Password to have a unique key and if password is changed finally.
-			providers::delete_cached_json(log_tag + " - cache", json_cache_dir, "RaGameID=" + QString::number(gameid));
+            providers::delete_cached_json(log_tag, json_cache_dir, "RaGameID=" + QString::number(gameid));
 			//to get Username
 			QString Username = QString::fromStdString(RecalboxConf::Instance().AsString("global.retroachievements.username"));
 			//Url to get Game details
@@ -934,9 +934,9 @@ void Metadata::build_md5_db(QString hashlibrary_url) const
     int size = 0;
 
     //Try to get RA hash library from cache
-    QJsonDocument json = providers::read_json_from_cache(m_log_tag + " - cache", m_json_cache_dir, "ra_hash_library");
+    QJsonDocument json = providers::read_json_from_cache(m_log_tag, m_json_cache_dir, "ra_hash_library");
 
-    Metadata::mRetroAchievementsGames = apply_hash_library_json(m_log_tag + " - cache", json);
+    Metadata::mRetroAchievementsGames = apply_hash_library_json(m_log_tag, json);
     if (Metadata::mRetroAchievementsGames.size() < 1)
     {
         //Delete JSON in cache by security
@@ -949,7 +949,7 @@ void Metadata::build_md5_db(QString hashlibrary_url) const
         //kill manager to avoid memory leaks
         delete manager;
 
-        Metadata::mRetroAchievementsGames = apply_hash_library_json(m_log_tag + " - cache", json);
+        Metadata::mRetroAchievementsGames = apply_hash_library_json(m_log_tag, json);
         if (Metadata::mRetroAchievementsGames.size() >= 1)
         {
             //saved in cache
@@ -1001,8 +1001,8 @@ int Metadata::set_RaHash_And_GameID(model::Game& game, bool ForceUpdate) const
             //calculate hash (using crc32) if missing
             crc32_hash_used =  calculateCRC32(romfile.toUtf8()).toUpper();
         }
-        QJsonDocument json_from_cache = providers::read_json_from_cache(m_log_tag + " - cache", m_json_cache_dir, game_ptr->collections().shortName() + "_" + crc32_hash_used);
-        md5_hash = apply_ra_hash_json(m_log_tag + " - cache", json_from_cache);
+        QJsonDocument json_from_cache = providers::read_json_from_cache(m_log_tag, m_json_cache_dir, game_ptr->collections().shortName() + "_" + crc32_hash_used);
+        md5_hash = apply_ra_hash_json(m_log_tag, json_from_cache);
 
         //Calculate md5 hash if not found from cache
         if (md5_hash == ""){

--- a/src/backend/providers/retroachievements/RetroAchievementsProvider.cpp
+++ b/src/backend/providers/retroachievements/RetroAchievementsProvider.cpp
@@ -33,14 +33,14 @@ RetroAchievementsProvider::RetroAchievementsProvider(QObject* parent)
 {}
 
 RetroAchievementsProvider::RetroAchievementsProvider(QString hashlibrary_url, QObject* parent)
-    : Provider(QLatin1String("retroAchievements"), QStringLiteral("RetroAchievements provider"), PROVIDER_FLAG_INTERNAL | PROVIDER_FLAG_HIDE_PROGRESS, parent)
+    : Provider(QLatin1String("retroAchievements"), QStringLiteral("RetroAchievements"), PROVIDER_FLAG_INTERNAL | PROVIDER_FLAG_HIDE_PROGRESS, parent)
     , m_hashlibrary_url(std::move(hashlibrary_url))
 {}
 
 Provider& RetroAchievementsProvider::run(SearchContext& sctx)
 {
     //Initialize Metahelper for each update and for each games for the moment
-    QString log_tag = "Retroachievements provider";
+    QString log_tag = "Retroachievements";
     try{
         providers::retroAchievements::Metadata metahelper(log_tag);
         //to verify and get token first

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1368,6 +1368,7 @@ Window {
                 powerDialog.item.message = qsTr("Pegasus will restart. Are you sure?");
                 powerDialog.focus = true;
             }
+            // FOR USB DRIVES/KEYS...
             else if(action === "usbmount-add"){
                 powerDialog.source = "dialogs/RestartDialog.qml";
                 powerDialog.item.message = qsTr("New USB device detected with ROMS directory, do you want to parse it now ?");
@@ -1378,6 +1379,7 @@ Window {
                 powerDialog.item.message = qsTr("USB device removed, do you want to refresh list of games ?");
                 powerDialog.focus = true;
             }
+            // FOR RETRODE...
             else if(action === "retrode-remove" && api.internal.recalbox.getBoolParameter("dumpers.retrode.enabled",false)){
                 apiconnection.onShowPopup("Video game cartridge reader", "RETRODE removed","",3);
                 //remove potential previous files about rom
@@ -1403,6 +1405,7 @@ Window {
                 dialogBoxRETRODETimer.cartridge_plugged = false;
                 dialogBoxRETRODETimer.start();
             }
+            // FOR USB-NES...
             else if(action === "usbnes-remove"  && api.internal.recalbox.getBoolParameter("dumpers.usbnes.enabled",false)){
                 apiconnection.onShowPopup("Video game cartridge reader", "USB-NES removed","",3);
                 //remove potential previous files about rom
@@ -1429,6 +1432,7 @@ Window {
                 dialogBoxUSBNESTimer.cartridge_plugged = false;
                 dialogBoxUSBNESTimer.start();
             }
+            // FOR CD-ROM...
             else if(action === "cdrom-eject"){
                 apiconnection.onShowPopup("Video game CD-ROM reader", "CD-ROM ejected","",3);
                 cdRomDialogBoxTimer.stop();

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -899,23 +899,23 @@ Window {
                 return;
             }
             var mountpoint = api.internal.system.run("cat /tmp/USBNES.mountpoint 2>/dev/null | tr -d '\\n' | tr -d '\\r'");
-            //console.log("USB-NES mountpoint : ", mountpoint)
+            //console.log("USBNES: mountpoint  - ", mountpoint)
             if(mountpoint.includes("/usb")) {
-                //console.log("USB-NES cartridge plugged: ", cartridge_plugged)
+                //console.log("USBNES: cartridge plugged - ", cartridge_plugged)
                 //check any change ?
                 var readflag = api.internal.system.run("cat " + mountpoint + "/pixl-read.flag" + " | tr -d '\\n' | tr -d '\\r'");
-                //console.log("USB-NES readflag: ", readflag);
+                //console.log("USBNES: readflag - ", readflag);
                 if(readflag !== "true"){
                     //get size of the rom detected
                     var romsize = api.internal.system.run("wc -c "+ mountpoint + "/rom.nes  | tr -d '\\n' | tr -d '\\r'");
-                    //console.log("USB-NES romsize: ", romsize)
+                    //console.log("USBNES: romsize - ", romsize)
                     //get previous crc32 if exists (including complete path of rom) to be able to compare it with previous one
                     var previousromcrc32 = api.internal.system.run("cat /tmp/USBNES.romcrc32 | tr -d '\\n' | tr -d '\\r'");
-                    //console.log("USB-NES previousromcrc32: ", previousromcrc32)
+                    //console.log("USBNES: previousromcrc32 - ", previousromcrc32)
                     //generate crc32 of the rom detected (including complete path of rom) to be able to compare it with previous one
                     //(don't try to match with screenscrapper one where header is added and/or done on zip file)
                     var romcrc32 = api.internal.system.run("crc32 " + mountpoint + "/rom.nes | tr -d '\\n' | tr -d '\\r'");
-                    //console.log("USB-NES romcrc32: ", romcrc32)
+                    //console.log("USBNES: romcrc32 - ", romcrc32)
                     if((parseInt(romsize) > 16)){
                         cartridge_plugged = true;
                         if(romcrc32 === previousromcrc32){
@@ -936,14 +936,14 @@ Window {
                         //api.internal.system.run("md5sum " + mountpoint + "/rom.nes | tr -d '\\n' | tr -d '\\r' > /tmp/USBNES.rommd5");
                         //calculate sha1 for PRG-ROM/SHR-ROM (don't try to match with screenscrapper one where it's done on full .nes/.zip file and including header)
                         var romsha1=api.internal.system.run("python3 /recalbox/scripts/nes_tools/nes_header_tools.py " + mountpoint + " rom.nes | tr -d '\\n' | tr -d '\\r'");
-                        //console.log("USB-NES romsha1: ", romsha1);
+                        //console.log("USBNES: romsha1 - ", romsha1);
                         //get info from nes 2.0 DB xml file
                         var rominfo=api.internal.system.run("grep -i " + romsha1 + " /recalbox/scripts/nes_tools/nes20db.xml -A4 -B3 | grep -i '<game>' | sed -n 's/.*<!-- \\(.*\\).nes.*/\\1/p' | tr -d '\\n' | tr -d '\\r'");
-                        //console.log("USB-NES rominfo: ", rominfo);
+                        //console.log("USBNES: rominfo - ", rominfo);
                         if(rominfo !== ""){
                             //check also if sav game exist
                             var savinfo=api.internal.system.run("ls "+ mountpoint + "/rom.sav 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                            //console.log("USB-NES savinfo: ", savinfo);
+                            //console.log("USBNES: savinfo - ", savinfo);
                             var savinfoflag = "N";
                             gameCartridge_save = "";
                             if(savinfo !== ""){
@@ -957,14 +957,14 @@ Window {
                             //to take first part that could contain type (licenced/playchoise/Vs. System/unlicensed...) and region (optionaly: PAL, North America, Japan, China, Taiwan & HongKong, ElseWhere, South Korea...)
                             //we will manage only cartdridge format and what we ahve with no-intro ;-)
                             var type_region = rominfo.split('\\')[0];
-                            //console.log("USB-NES type_region: ", type_region);
+                            //console.log("USBNES: type_region - ", type_region);
                             gameCartridge_type = type_region.split(' ')[0];
-                            //console.log("USB-NES gameCartridge_type: ", gameCartridge_type);
+                            //console.log("USBNES: gameCartridge_type - ", gameCartridge_type);
                             gameCartridge_region = type_region.replace(gameCartridge_type,"");
                             //finally we trim region here for later
                             var regex = RegExp("^\\s*(.*?)\\s*$");
                             gameCartridge_region = gameCartridge_region.replace(regex, "$1");
-                            //console.log("USB-NES region: '",gameCartridge_region,"'");
+                            //console.log("USBNES: region: '",gameCartridge_region,"'");
                             if(gameCartridge_region !== ""){
                                 var region_index = getRegionIndex(gameCartridge_region);
                                 if(region_index !== -1){
@@ -984,7 +984,7 @@ Window {
 
                                 var existingRom = ""
                                 existingRom = api.internal.system.run("grep -i " + romsha1 + " /recalbox/share/roms/usb-nes.romlist.csv | tr -d '\\n' | tr -d '\\r'");
-                                //console.log("existingRom : ",existingRom);
+                                //console.log("existingRom  - ",existingRom);
                                 if(existingRom === ""){
                                     //format GAME TITLE,REGION,TYPE,WORKS,SAVE FOUND;SHA1 for PRG-ROM/SHR-ROM,DUMPER VERSION,WHEN,COMMENT
                                     var now = new Date();
@@ -1010,7 +1010,7 @@ Window {
                                 var targetedDump = "/recalbox/share/dumps/" + gameCartridge_name + " (" + gameCartridge_region + ")" + " (" + gameCartridge_type + ") [" + romcrc32.split(' ')[0] + "].nes";
                                 //console.log("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                                 var existingDump = api.internal.system.run("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                                //console.log("existingDump : ",existingDump);
+                                //console.log("existingDump  - ",existingDump);
                                 //for the moment: we don't dump rom if already exists in dumps directory / no proposal to erase in this case
                                 //manual move/erase to do in share dumps directory in this case
                                 if(!existingDump.includes("/recalbox/share/dumps/")){
@@ -1063,11 +1063,11 @@ Window {
                         gameCartridge_crc32 = "";
                         gameCartridge_name = "";
                     }
-                    //console.log("USB-NES gameCartridge (full description from NESDB 2.0) : ", gameCartridge);
-                    //console.log("USB-NES gameCartridge_region (no-intro regions) : ", gameCartridge_region);
-                    //console.log("USB-NES gameCartridge_system (pixL system shortname): ", gameCartridge_system);
-                    //console.log("USB-NES gameCartridge_state : ", gameCartridge_state);
-                    //console.log("USB-NES gameCartridge_name (name extracted to help for search in gamelists): ", gameCartridge_name);
+                    console.log("USBNES: gameCartridge (full description from NESDB 2.0) - ", gameCartridge);
+                    console.log("USBNES: gameCartridge_region (no-intro regions) - ", gameCartridge_region);
+                    console.log("USBNES: gameCartridge_system (pixL system shortname) - ", gameCartridge_system);
+                    console.log("USBNES: gameCartridge_state - ", gameCartridge_state);
+                    console.log("USBNES: gameCartridge_name (name extracted to help for search in gamelists) - ", gameCartridge_name);
                     //set read.flag to "true"
                     api.internal.system.run("echo '" + true + "' | tr -d '\\n' | tr -d '\\r' > " + mountpoint + "/pixl-read.flag");
                 }
@@ -1089,23 +1089,23 @@ Window {
                 return;
             }
             var mountpoint = api.internal.system.run("cat /tmp/RETRODE.mountpoint 2>/dev/null | tr -d '\\n' | tr -d '\\r'");
-            //console.log("RETRODE mountpoint : ", mountpoint)
+            //console.log("RETRODE: mountpoint  - ", mountpoint)
             if(mountpoint.includes("/usb")) {
-                //console.log("RETRODE cartridge plugged: ", cartridge_plugged)
+                //console.log("RETRODE: cartridge plugged - ", cartridge_plugged)
                 //get list of extensions from RETRODE.CFG (always with this order in this file after restart and conf : snes,megadrive,n64,gb,gba,mastersystem,gamegear)
                 //console.log("grep -i 'RomExt' "+ mountpoint + "/RETRODE.CFG  | awk -F' ' '{print $2}' | paste -s -d ',' | tr -d '\\n' | tr -d '\\r'");
                 var romsExt = api.internal.system.run("grep -i 'RomExt' "+ mountpoint + "/RETRODE.CFG  | awk -F' ' '{print $2}' | paste -s -d ',' | tr -d '\\n' | tr -d '\\r'");
-                //console.log("RETRODE romsExt ",romsExt);
+                //console.log("RETRODE: romsExt ",romsExt);
                 //find rom using existing extension
                 var fileFound = "";
                 var systemFound = "";
                 for(var i=0; i<7; i++){
                     //console.log("ls " + mountpoint + "/*." + romsExt.split(",")[i] + " 2>/dev/null | tr -d '\\n' | tr -d '\\r'");
                     fileFound = api.internal.system.run("ls " + mountpoint + "/*." + romsExt.split(",")[i] + " 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                    //console.log("RETRODE fileFound for ",retrode_systems_list.split(",")[i], " : ", fileFound)
+                    //console.log("RETRODE: fileFound for ",retrode_systems_list.split(",")[i], "  - ", fileFound)
                     if(fileFound !== ""){
                         systemFound = retrode_systems_list.split(",")[i];
-                        //console.log("RETRODE systemFound : ",systemFound)
+                        //console.log("RETRODE: systemFound  - ",systemFound)
                         break;
                     }
                 }
@@ -1151,12 +1151,12 @@ Window {
                     gameCartridge_state = ""
                     gameCartridge_name = "";
                 }
-                //console.log("RETRODE gameCartridge (from file name) : ", gameCartridge);
-                //console.log("RETRODE gameCartridge_region (no-intro regions) : ", gameCartridge_region);
-                //console.log("RETRODE gameCartridge_system (pixL system shortname): ", gameCartridge_system);
-                //console.log("RETRODE gameCartridge_crc32 (as in gamelist for snes): ", gameCartridge_crc32);
-                //console.log("RETRODE gameCartridge_state : ", gameCartridge_state);
-                //console.log("RETRODE gameCartridge_name (name extracted to help for search in gamelists): ", gameCartridge_name);
+                //console.log("RETRODE: gameCartridge (from file name) - ", gameCartridge);
+                //console.log("RETRODE: gameCartridge_region (no-intro regions) - ", gameCartridge_region);
+                //console.log("RETRODE: gameCartridge_system (pixL system shortname) - ", gameCartridge_system);
+                //console.log("RETRODE: gameCartridge_crc32 (as in gamelist for snes) - ", gameCartridge_crc32);
+                //console.log("RETRODE: gameCartridge_state - ", gameCartridge_state);
+                //console.log("RETRODE: gameCartridge_name (name extracted to help for search in gamelists) - ", gameCartridge_name);
                 //set read.flag but empty
                 api.internal.system.run("echo '' | tr -d '\\n' | tr -d '\\r' > " + mountpoint + "/pixl-read.flag");
             }
@@ -1177,22 +1177,22 @@ Window {
         property string systemFound: ""
         property string romExt: ""
         onTriggered: {
-            //console.log("RETRODE mountpoint : ", mountpoint)
+            //console.log("RETRODE: mountpoint  - ", mountpoint)
             if(mountpoint.includes("/usb")) {
-                //console.log("RETRODE cartridge plugged: ", cartridge_plugged)
-                //console.log("RETRODE romExt ",romExt);
-                //console.log("RETRODE fileFound for ",systemFound, " : ", fileFound)
+                //console.log("RETRODE: cartridge plugged - ", cartridge_plugged)
+                //console.log("RETRODE: romExt ",romExt);
+                //console.log("RETRODE: fileFound for ",systemFound, "  - ", fileFound)
                 //get size of the rom detected
                 var romsize = api.internal.system.run("wc -c "+ fileFound + "  | tr -d '\\n' | tr -d '\\r'");
                 if(isDebugEnv()) api.internal.system.run("sleep 4"); //to simulate slownness when we read rom file for the first time
                 genericMessage.focus = false;
-                //console.log("RETRODE romsize: ", romsize)
+                //console.log("RETRODE: romsize - ", romsize)
                 //get previous crc32 if exists (including complete path of rom) to be able to compare it with previous one
                 var previousromcrc32 = api.internal.system.run("cat /tmp/RETRODE.romcrc32 | tr -d '\\n' | tr -d '\\r'");
-                //console.log("RETRODE previousromcrc32: ", previousromcrc32)
+                //console.log("RETRODE: previousromcrc32 - ", previousromcrc32)
                 //generate crc32 of the rom detected (including complete path of rom) to be able to compare it with previous one
                 var romcrc32 = api.internal.system.run("crc32 " + fileFound + " | tr -d '\\n' | tr -d '\\r'");
-                //console.log("RETRODE romcrc32: ", romcrc32)
+                //console.log("RETRODE: romcrc32 - ", romcrc32)
                 if(romcrc32 === previousromcrc32){
                     gameCartridge_state = "reloaded";
                     //show popup to say that is a reset
@@ -1212,7 +1212,7 @@ Window {
                 //get info from file name (first part)
                 var romfilename=fileFound.replace(mountpoint + "/","");
                 var rominfo=romfilename.replace("." + romExt,"");
-                //console.log("RETRODE rominfo: ", rominfo);
+                //console.log("RETRODE: rominfo - ", rominfo);
                 if(rominfo !== ""){
                     //check also if sav game exist
                     //but we should exclude 3 files for that
@@ -1221,7 +1221,7 @@ Window {
                     var value3 = "RETRODE.CFG"
                     //console.log("ls -1 "+ mountpoint + " 2>/dev/null | grep -vE '^(" + value1 +"|" + value2 + "|" + value3 + ")$' | tr -d '\\n' | tr -d '\\r'");
                     var savinfo=api.internal.system.run("ls -1 "+ mountpoint + " 2>/dev/null | grep -vE '^(" + value1 +"|" + value2 + "|" + value3 + ")$' | tr -d '\\n' | tr -d '\\r'");
-                    //console.log("RETRODE savinfo: ", savinfo);
+                    //console.log("RETRODE: savinfo - ", savinfo);
                     var savinfoflag = "N";
                     gameCartridge_save = "";
                     if(savinfo !== ""){
@@ -1230,15 +1230,15 @@ Window {
                         gameCartridge_save = mountpoint + "/" + savinfo;
                     }
                     gameCartridge_state = "identified";
-                    //console.log("RETRODE gameCartridge_state: ", gameCartridge_state);
+                    //console.log("RETRODE: gameCartridge_state - ", gameCartridge_state);
                     gameCartridge = rominfo;
-                    //console.log("RETRODE gameCartridge: ", gameCartridge);
+                    //console.log("RETRODE: gameCartridge - ", gameCartridge);
                     gameCartridge_type = ""; //empty for RETRODE
-                    //console.log("RETRODE gameCartridge_type: ", gameCartridge_type);
+                    //console.log("RETRODE: gameCartridge_type - ", gameCartridge_type);
                     gameCartridge_region = ""; //empty for RETRODE
-                    //console.log("RETRODE gameCartridge_region: ", gameCartridge_region);
+                    //console.log("RETRODE: gameCartridge_region - ", gameCartridge_region);
                     gameCartridge_name = ""; //let it empty to search only by crc32
-                    //console.log("RETRODE gameCartridge_name: ", gameCartridge_name);
+                    //console.log("RETRODE: gameCartridge_name - ", gameCartridge_name);
                     //check if option to save rominfo/crc32 is requested
                     if(api.internal.recalbox.getBoolParameter("dumpers.retrode.romlist",false)){
                         var existingFile = ""
@@ -1249,7 +1249,7 @@ Window {
                         }
                         var existingRom = ""
                         existingRom = api.internal.system.run("grep -i " + romcrc32 + " /recalbox/share/roms/retrode.romlist.csv | tr -d '\\n' | tr -d '\\r'");
-                        //console.log("existingRom : ",existingRom);
+                        //console.log("existingRom  - ",existingRom);
                         if(existingRom === ""){
                             //format GAME TITLE,SYSTEM,WORKS,SAVE FOUND;CRC32 FILE CHECKSUM,DUMPER VERSION,WHEN,COMMENT
                             var now = new Date();
@@ -1266,13 +1266,13 @@ Window {
                     gameCartridge_system = systemFound;
                     //to do last because will trig changes
                     gameCartridge_crc32 = romcrc32.split(" ")[0];//need to take first part only because file name/path is inlcuded in result of CRC32 calculation
-                    //console.log("RETRODE gameCartridge_crc32: ", gameCartridge_crc32);
+                    //console.log("RETRODE: gameCartridge_crc32 - ", gameCartridge_crc32);
                     //dump of rom if request
                     if(api.internal.recalbox.getBoolParameter("dumpers.retrode.savedump",false)){
                         var targetedDump = "/recalbox/share/dumps/" + rominfo + " [" + gameCartridge_crc32 + "]." + romExt;
                         //console.log("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                         var existingDump = api.internal.system.run("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                        //console.log("existingDump : ",existingDump);
+                        //console.log("existingDump  - ",existingDump);
                         //for the moment: we don't dump rom if already exists in dumps directory / no proposal to erase in this case
                         //manual move/erase to do in share dumps directory in this case
                         if(!existingDump.includes("/recalbox/share/dumps/")){
@@ -1285,12 +1285,12 @@ Window {
                 //propose cartridge dialog box in this case
                 cartridgeDialogBoxLoader.visible = true; //to show
                 cartridgeDialogBoxLoader.focus = true; //to have focus
-                //console.log("RETRODE gameCartridge (from file name) : ", gameCartridge);
-                //console.log("RETRODE gameCartridge_region (no-intro regions) : ", gameCartridge_region);
-                //console.log("RETRODE gameCartridge_system (pixL system shortname): ", gameCartridge_system);
-                //console.log("RETRODE gameCartridge_crc32 (as in gamelist for snes): ", gameCartridge_crc32);
-                //console.log("RETRODE gameCartridge_state : ", gameCartridge_state);
-                //console.log("RETRODE gameCartridge_name (name extracted to help for search in gamelists): ", gameCartridge_name);
+                console.log("RETRODE: gameCartridge (from file name) - ", gameCartridge);
+                console.log("RETRODE: gameCartridge_region (no-intro regions) - ", gameCartridge_region);
+                console.log("RETRODE: gameCartridge_system (pixL system shortname) - ", gameCartridge_system);
+                console.log("RETRODE: gameCartridge_crc32 (as in gamelist for snes) - ", gameCartridge_crc32);
+                console.log("RETRODE: gameCartridge_state - ", gameCartridge_state);
+                console.log("RETRODE: gameCartridge_name (name extracted to help for search in gamelists) - ", gameCartridge_name);
             }
         }
     }
@@ -1309,35 +1309,35 @@ Window {
                 return;
             }
             var mountpoint = "/tmp"; //use tmp directory for gboperator because no mountpoint exists in this case
-            //console.log("gboperator 'virtual' mountpoint : ", mountpoint)
+            //console.log("gboperator 'virtual' mountpoint  - ", mountpoint)
             if(mountpoint.includes("/tmp")) { //stupid test just to keep same structucode than USBNES ;-)
-                //console.log("GB OPERATOR cartridge plugged: ", cartridge_plugged)
+                //console.log("GBOPERATOR: cartridge plugged - ", cartridge_plugged)
                 //check any change ?
                 var readflag = api.internal.system.run("cat " + mountpoint + "/GBOPERATOR.readflag" + " | tr -d '\\n' | tr -d '\\r'");
-                //console.log("GB OPERATOR readflag: ", readflag);
+                //console.log("GBOPERATOR: readflag - ", readflag);
                 if(readflag !== "true"){
                     //in case of GB operator, the gameinfo contains the ROM file name with extension for the moment
                     var romfile = api.internal.system.run("cat /tmp/GBOPERATOR.gamedumped | tr -d '\\n' | tr -d '\\r'");
                     //just file name without extension for the moment in rominfo
                     var parts = romfile.split(".");
                     var rominfo = parts.slice(0, -1).join(".");
-                    //console.log("GB OPERATOR rominfo: ", rominfo);
+                    //console.log("GBOPERATOR: rominfo - ", rominfo);
                     //get system from romfile extension (gb or gbc, gba not yet supported)
                     var system =  romfile.split('.').pop();
-                    //console.log("GB OPERATOR system: ", system)
+                    //console.log("GBOPERATOR: system - ", system)
                     //get size of the rom detected
-                    console.log("wc -c \""+ mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
+                    //console.log("GBOPERATOR: wc -c \""+ mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
                     var romsize = api.internal.system.run("wc -c \""+ mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
-                    //console.log("GB OPERATOR romsize: ", romsize)
+                    //console.log("GBOPERATOR: romsize - ", romsize)
                     //get previous crc32 if exists (including complete path of rom) to be able to compare it with previous one
                     var previousromcrc32 = api.internal.system.run("cat /tmp/GBOPERATOR.romcrc32 | tr -d '\\n' | tr -d '\\r'");
-                    //console.log("GB OPERATOR previousromcrc32: ", previousromcrc32)
+                    //console.log("GBOPERATOR: previousromcrc32 - ", previousromcrc32)
                     //generate crc32 of the rom detected (including complete path of rom) to be able to compare it with previous one
                     //(don't try to match with screenscrapper one where header is added and/or done on zip file)
-                    //console.log("crc32 \"" + mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
+                    //console.log("GBOPERATOR: crc32 \"" + mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
                     var romcrc32 = api.internal.system.run("crc32 \"" + mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
-                    //console.log("GB OPERATOR romcrc32:", romcrc32)
-                    //console.log("GB OPERATOR parseInt(romsize):", parseInt(romsize).toString())
+                    //console.log("GBOPERATOR: romcrc32:", romcrc32)
+                    //console.log("GBOPERATOR: parseInt(romsize):", parseInt(romsize).toString())
                     if((parseInt(romsize) >= 32768)){
                         cartridge_plugged = true;
                         if(romcrc32 === previousromcrc32){
@@ -1359,7 +1359,7 @@ Window {
                         if(rominfo !== ""){
                             //check also if sav game exist
                             var savinfo=api.internal.system.run("ls \""+ mountpoint + "/" + rominfo + ".sav\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                            console.log("GB OPERATOR savinfo: ", savinfo);
+                            console.log("GBOPERATOR: savinfo - ", savinfo);
                             var savinfoflag = "N";
                             gameCartridge_save = "";
                             if(savinfo !== ""){
@@ -1370,9 +1370,9 @@ Window {
                             gameCartridge_state = "identified";
                             gameCartridge = rominfo;
                             gameCartridge_type = ""; // NA - not really possible t well discriminate
-                            console.log("GB OPERATOR gameCartridge_type:", gameCartridge_type);
+                            //console.log("GBOPERATOR: gameCartridge_type - ", gameCartridge_type);
                             gameCartridge_region = ""; // NA - not really possible t well discriminate
-                            console.log("GB OPERATOR region:",gameCartridge_region);
+                            //console.log("GBOPERATOR: region - ",gameCartridge_region);
                             gameCartridge_region_regex = "";
                             //check if option to save rominfo/crc32 is requested
                             if(api.internal.recalbox.getBoolParameter("dumpers.gboperator.romlist",false)){
@@ -1385,17 +1385,17 @@ Window {
 
                                 var existingRom = ""
                                 existingRom = api.internal.system.run("grep -i " + romcrc32 + " /recalbox/share/roms/usb-nes.romlist.csv | tr -d '\\n' | tr -d '\\r'");
-                                //console.log("existingRom : ",existingRom);
+                                //console.log("GBOPERATOR: existingRom  - ",existingRom);
                                 if(existingRom === ""){
                                     //format GAME TITLE,WORKS,SAVE FOUND;ROM CRC32,DUMPER VERSION,WHEN,COMMENT
                                     var now = new Date();
                                     var formattedDateTime = now.toString("yyyy-MM-dd hh:mm:ss");
-                                    //console.log("Formatted date and time:", formattedDateTime);
+                                    //console.log("GBOPERATOR: Formatted date and time - ", formattedDateTime);
                                     if(gboperatorVersion === ""){
                                         //read GB OPERATOR version and store it in global variable
                                         gboperatorVersion = "1.0" // fix version for the moment, need to investigate if possible to have it from GB OPERATOR ?!
                                     }
-                                    //console.log('echo "' + rominfo + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
+                                    //console.log('GBOPERATOR: echo "' + rominfo + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
                                     api.internal.system.run('echo "' + rominfo + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
 
                                 }
@@ -1403,19 +1403,19 @@ Window {
                             gameCartridge_system = system;
                             //to do last because will trig changes
                             gameCartridge_crc32 = romcrc32.split(" ")[0];//need to take first part only because file name/path is inlcuded in result of CRC32 calculation
-                            //console.log("GBOPERATOR gameCartridge_crc32: ", gameCartridge_crc32);
+                            //console.log("GBOPERATOR: gameCartridge_crc32 - ", gameCartridge_crc32);
                             gameCartridge_name = rominfo;
                             //dump of rom if request
                             if(api.internal.recalbox.getBoolParameter("dumpers.gboperator.savedump",false)){
                                 var targetedDump = "/recalbox/share/dumps/" + gameCartridge_name  + " [" + romcrc32.split(' ')[0] + "].gb";
-                                //console.log("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                                //console.log("GBOPERATOR: ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                                 var existingDump = api.internal.system.run("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                                //console.log("existingDump : ",existingDump);
+                                //console.log("GBOPERATOR: existingDump  - ",existingDump);
                                 //for the moment: we don't dump rom if already exists in dumps directory / no proposal to erase in this case
                                 //manual move/erase to do in share dumps directory in this case
                                 if(!existingDump.includes("/recalbox/share/dumps/")){
                                     //copy of rom as dump
-                                    //console.log("cp '" + gameCartridge_rom + "' '" + targetedDump + "'");
+                                    //console.log("GBOPERATOR: cp '" + gameCartridge_rom + "' '" + targetedDump + "'");
                                     api.internal.system.run("cp '" + gameCartridge_rom + "' '" + targetedDump + "'");
                                 }
                             }
@@ -1435,11 +1435,12 @@ Window {
                         cartridgeDialogBoxLoader.visible = true; //to show
                         cartridgeDialogBoxLoader.focus = true; //to have focus
                     }
-                    console.log("GB OPERATOR gameCartridge (full description) : ", gameCartridge);
-                    console.log("GB OPERATOR gameCartridge_region (no-intro regions) : ", gameCartridge_region);
-                    console.log("GB OPERATOR gameCartridge_system (pixL system shortname): ", gameCartridge_system);
-                    console.log("GB OPERATOR gameCartridge_state : ", gameCartridge_state);
-                    console.log("GB OPERATOR gameCartridge_name (name extracted to help for search in gamelists): ", gameCartridge_name);
+                    console.log("GBOPERATOR: gameCartridge (full description) - ", gameCartridge);
+                    console.log("GBOPERATOR: gameCartridge_region (no-intro regions) - ", gameCartridge_region);
+                    console.log("GBOPERATOR: gameCartridge_system (pixL system shortname) - ", gameCartridge_system);
+                    console.log("GBOPERATOR: gameCartridge_state - ", gameCartridge_state);
+                    console.log("GBOPERATOR: gameCartridge_name (name extracted to help for search in gamelists) - ", gameCartridge_name);
+                    console.log("GBOPERATOR: gameCartridge_crc32 - ", gameCartridge_crc32);
                     //set read.flag to "true"
                     api.internal.system.run("echo '" + true + "' | tr -d '\\n' | tr -d '\\r' > " + mountpoint + "/GBOPERATOR.readflag");
                 }

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -750,6 +750,7 @@ Window {
             var targetedSave = "";
             var targetedRom = "";
             var existingSave = "";
+
             if(gameCartridge_save.includes("rom.sav") && api.internal.recalbox.getBoolParameter("dumpers.usbnes.movesave",false)){
                 //get crc32 to ahve it in name of files as reference to improve unicity
                 romcrc32 = api.internal.system.run("cat /tmp/USBNES.romcrc32 | tr -d '\\n' | tr -d '\\r'");
@@ -816,6 +817,7 @@ Window {
                 //need to reset rom full path in this case
                 api.internal.singleplay.setFile(targetedRom);
             }
+
             // connect game to launcher
             api.connectGameFiles(api.internal.singleplay.game);
             // launch this Game
@@ -1297,7 +1299,7 @@ Window {
     Timer {
         id: dialogBoxGBOPERATORTimer
         interval: 5000
-        triggeredOnStart: false
+        triggeredOnStart: true
         repeat: true
         running: (splashScreen.focus) ? false : true
         property bool cartridge_plugged: false
@@ -1307,24 +1309,35 @@ Window {
                 return;
             }
             var mountpoint = "/tmp"; //use tmp directory for gboperator because no mountpoint exists in this case
-            //console.log("gboperator "virtual" mountpoint : ", mountpoint)
+            console.log("gboperator 'virtual' mountpoint : ", mountpoint)
             if(mountpoint.includes("/tmp")) { //stupid test just to keep same structucode than USBNES ;-)
-                //console.log("GB OPERATOR cartridge plugged: ", cartridge_plugged)
+                console.log("GB OPERATOR cartridge plugged: ", cartridge_plugged)
                 //check any change ?
-                var readflag = api.internal.system.run("cat " + mountpoint + "/pixl-read.flag" + " | tr -d '\\n' | tr -d '\\r'");
-                //console.log("GB OPERATOR readflag: ", readflag);
+                var readflag = api.internal.system.run("cat " + mountpoint + "/GBOPERATOR.readflag" + " | tr -d '\\n' | tr -d '\\r'");
+                console.log("GB OPERATOR readflag: ", readflag);
                 if(readflag !== "true"){
+                    //in case of GB operator, the gameinfo contains the ROM file name with extension for the moment
+                    var romfile = api.internal.system.run("cat /tmp/GBOPERATOR.gamedumped | tr -d '\\n' | tr -d '\\r'");
+                    //just file name without extension for the moment in rominfo
+                    var parts = romfile.split(".");
+                    var rominfo = parts.slice(0, -1).join(".");
+                    console.log("GB OPERATOR rominfo: ", rominfo);
+                    //get system from romfile extension (gb or gbc, gba not yet supported)
+                    var system =  romfile.split('.').pop();
+                    console.log("GB OPERATOR system: ", system)
                     //get size of the rom detected
-                    var romsize = api.internal.system.run("wc -c "+ mountpoint + "/rom.gb  | tr -d '\\n' | tr -d '\\r'");
-                    //console.log("GB OPERATOR romsize: ", romsize)
+                    console.log("wc -c \""+ mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
+                    var romsize = api.internal.system.run("wc -c \""+ mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
+                    console.log("GB OPERATOR romsize: ", romsize)
                     //get previous crc32 if exists (including complete path of rom) to be able to compare it with previous one
                     var previousromcrc32 = api.internal.system.run("cat /tmp/GBOPERATOR.romcrc32 | tr -d '\\n' | tr -d '\\r'");
-                    //console.log("GB OPERATOR previousromcrc32: ", previousromcrc32)
+                    console.log("GB OPERATOR previousromcrc32: ", previousromcrc32)
                     //generate crc32 of the rom detected (including complete path of rom) to be able to compare it with previous one
                     //(don't try to match with screenscrapper one where header is added and/or done on zip file)
-                    var romcrc32 = api.internal.system.run("crc32 " + mountpoint + "/rom.gb | tr -d '\\n' | tr -d '\\r'");
-                    //console.log("GB OPERATOR romcrc32: ", romcrc32)
-                    if((parseInt(romsize) > 16)){
+                    console.log("crc32 \"" + mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
+                    var romcrc32 = api.internal.system.run("crc32 \"" + mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
+                    console.log("GB OPERATOR romcrc32: ", romcrc32)
+                    if((parseInt(romsize) >= 32768)){
                         cartridge_plugged = true;
                         if(romcrc32 === previousromcrc32){
                             gameCartridge_state = "reloaded";
@@ -1334,26 +1347,24 @@ Window {
                         //just set "cartridge" as title of this game (optional)
                         api.internal.singleplay.setTitle("cartridge");
                         //set rom full path
-                        gameCartridge_rom = mountpoint + "/rom.gb";
+                        gameCartridge_rom = mountpoint + "/" + romfile;
                         api.internal.singleplay.setFile(gameCartridge_rom);
                         //set system to select to run this rom
-                        api.internal.singleplay.setSystem("gb"); //using shortName
+                        api.internal.singleplay.setSystem(system); //using shortName
                         //store new crc32 (including complete path of rom) and store it for the moment
                         api.internal.system.run("echo '" + romcrc32 + "' | tr -d '\\n' | tr -d '\\r' > /tmp/GBOPERATOR.romcrc32");
                         //RFU: generate md5 (including complete path of rom) and store it for the moment
                         //api.internal.system.run("md5sum " + mountpoint + "/rom.nes | tr -d '\\n' | tr -d '\\r' > /tmp/GBOPERATOR.rommd5");
-                        var rominfo = api.internal.system.run("cat /tmp/GBOPERATOR.gamefound | tr -d '\\n' | tr -d '\\r'");
-                        //console.log("GB OPERATOR rominfo: ", rominfo);
                         if(rominfo !== ""){
                             //check also if sav game exist
-                            var savinfo=api.internal.system.run("ls "+ mountpoint + "/rom.sav 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                            var savinfo=api.internal.system.run("ls \""+ mountpoint + "/" + rominfo + ".sav\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                             //console.log("GB OPERATOR savinfo: ", savinfo);
                             var savinfoflag = "N";
                             gameCartridge_save = "";
                             if(savinfo !== ""){
                                 savinfoflag = "Y";
                                 //just communicate that sav is available
-                                gameCartridge_save = mountpoint + "/rom.sav";
+                                gameCartridge_save = mountpoint + "/" + romname +".sav";
                             }
                             gameCartridge_state = "identified";
                             gameCartridge = rominfo;
@@ -1398,17 +1409,17 @@ Window {
                                         //read GB OPERATOR version and store it in global variable
                                         gboperatorVersion = "1.0" // fix version for the moment, need to investigate if possible to have it from GB OPERATOR ?!
                                     }
-                                    //console.log('echo "' + rominfo.split('\\')[1] + ';' + region + ';' + gameCartridge_type + ';' +  'Y' + ';' + savinfoflag + ';' +  romsha1 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
-                                    api.internal.system.run('echo "' + rominfo.split('\\')[1] + ';' + region + ';' + gameCartridge_type + ';' +  'Y' + ';' + savinfoflag + ';' +  romsha1 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
+                                    //console.log('echo "' + rominfo + ';' + region + ';' + gameCartridge_type + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
+                                    api.internal.system.run('echo "' + rominfo + ';' + region + ';' + gameCartridge_type + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
 
                                 }
                             }
-                            gameCartridge_system = "gb";
+                            gameCartridge_system = system;
                             //to do last because will trig changes
                             gameCartridge_crc32 = "";
                             //remove data between [] and () in name as: (rev 1), (rev 2)
                             regex = /\([^()]*\)|\[[^\]]*\]/;
-                            gameCartridge_name = rominfo.split('\\')[1].replace(regex, "");
+                            gameCartridge_name = rominfo.replace(regex, "");
                             //dump of rom if request
                             if(api.internal.recalbox.getBoolParameter("dumpers.gboperator.savedump",false)){
                                 var targetedDump = "/recalbox/share/dumps/" + gameCartridge_name + " (" + gameCartridge_region + ")" + " (" + gameCartridge_type + ") [" + romcrc32.split(' ')[0] + "].gb";
@@ -1439,41 +1450,13 @@ Window {
                         cartridgeDialogBoxLoader.visible = true; //to show
                         cartridgeDialogBoxLoader.focus = true; //to have focus
                     }
-                    else if((parseInt(romsize) <= 16) && (cartridge_plugged === true)){
-                        cartridge_plugged = false;
-                        //remove potential previous files about rom
-                        api.internal.system.run("rm /tmp/USBNES.romcrc32");
-                        //RFU: api.internal.system.run("rm /tmp/USBNES.rommd5");
-                        cartridgeDialogBoxLoader.focus = false; //to unfocus if displayed
-                        cartridgeDialogBoxLoader.visible = false; //to hide if displayed
-                        //show popup to say that game has been removed
-                        apiconnection.onShowPopup(qsTr("Video game cartridge reader"), qsTr("USB-NES cartridge unplugged"),"",3);
-                        gameCartridge = "";
-                        gameCartridge_region = "";
-                        gameCartridge_system = "";
-                        gameCartridge_state = "unplugged";
-                        gameCartridge_crc32 = "";
-                        gameCartridge_name = "";
-                    }
-                    else if((parseInt(romsize) <= 16)){
-                        cartridgeDialogBoxLoader.focus = false; //to unfocus if displayed
-                        cartridgeDialogBoxLoader.visible = false; //to hide if displayed
-                        //show popup to alert that we didn't detected the game
-                        apiconnection.onShowPopup(qsTr("Video game cartridge reader"), qsTr("USB-NES no cartridge detected"),"",3);
-                        gameCartridge = "";
-                        gameCartridge_region = "";
-                        gameCartridge_system = "";
-                        gameCartridge_state = "";
-                        gameCartridge_crc32 = "";
-                        gameCartridge_name = "";
-                    }
-                    //console.log("USB-NES gameCartridge (full description from NESDB 2.0) : ", gameCartridge);
-                    //console.log("USB-NES gameCartridge_region (no-intro regions) : ", gameCartridge_region);
-                    //console.log("USB-NES gameCartridge_system (pixL system shortname): ", gameCartridge_system);
-                    //console.log("USB-NES gameCartridge_state : ", gameCartridge_state);
-                    //console.log("USB-NES gameCartridge_name (name extracted to help for search in gamelists): ", gameCartridge_name);
+                    console.log("GB OPERATOR gameCartridge (full description) : ", gameCartridge);
+                    console.log("GB OPERATOR gameCartridge_region (no-intro regions) : ", gameCartridge_region);
+                    console.log("GB OPERATOR gameCartridge_system (pixL system shortname): ", gameCartridge_system);
+                    console.log("GB OPERATOR gameCartridge_state : ", gameCartridge_state);
+                    console.log("GB OPERATOR gameCartridge_name (name extracted to help for search in gamelists): ", gameCartridge_name);
                     //set read.flag to "true"
-                    api.internal.system.run("echo '" + true + "' | tr -d '\\n' | tr -d '\\r' > " + mountpoint + "/pixl-read.flag");
+                    api.internal.system.run("echo '" + true + "' | tr -d '\\n' | tr -d '\\r' > " + mountpoint + "/GBOPERATOR.readflag");
                 }
             }
         }
@@ -1539,8 +1522,8 @@ Window {
             genericMessage.focus = true;
         }
         function onRequestAction(action, parameterList) {
-            //console.log("New action requested : ", action);
-            //console.log("parameterList content : ", parameterList);
+            console.log("New action requested : ", action);
+            console.log("parameterList content : ", parameterList);
             if(action === "shutdown"){
                 powerDialog.source = "dialogs/ShutdownDialog.qml"
                 powerDialog.focus = true;
@@ -1632,11 +1615,8 @@ Window {
                 cdRomDialogBoxTimer.start();
             }
             // FOR EPILOGUE GB OPERATOR...
-            else if(action === "gboperator-remove" && api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false)){
-                apiconnection.onShowPopup("Video game cartridge reader", "GB OPERATOR removed","",3);
-                //remove potential previous files about rom
-                api.internal.system.run("rm /tmp/GBOPERATOR.romcrc32");
-                //RFU: api.internal.system.run("rm /tmp/GBOPERATOR.rommd5");
+            else if(action.includes("gboperator-remove") && api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false)){
+                apiconnection.onShowPopup("Video game cartridge reader", "GB Operator unplugged","",3);
                 //remove cartridge also and stop timer to find roms/saves from GBOPERATOR
                 dialogBoxGBOPERATORTimer.cartridge_plugged = false;
                 dialogBoxGBOPERATORTimer.stop();
@@ -1646,14 +1626,38 @@ Window {
                 gameCartridge_region = "";
                 gameCartridge_state = "disconnected";
                 gameCartridge_name = "";
+                //remove potential previous files about rom
+                api.internal.system.run("rm /tmp/GBOPERATOR.romcrc32");
+                api.internal.system.run("rm /tmp/GBOPERATOR.readflag");
+                //RFU: api.internal.system.run("rm /tmp/GBOPERATOR.rommd5");
             }
             else if(action.includes("gboperator-add") && api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false)){
                 apiconnection.onShowPopup("Video game cartridge reader", "GB Operator plugged","",3);
+            }
+            else if(action.includes("gboperator-gameinserted") && api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false)){
+                apiconnection.onShowPopup("Video game cartridge reader", "GB Operator - Game inserted","",3);
+            }
+            else if(action.includes("gboperator-gamedumped") && api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false)){
                 //run timer to find roms/saves from GB Operator
                 dialogBoxGBOPERATORTimer.cartridge_plugged = false;
                 dialogBoxGBOPERATORTimer.start();
             }
-
+            else if(action.includes("gboperator-gameremoved") && api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false)){
+                apiconnection.onShowPopup("Video game cartridge reader", "GB Operator - Game removed","",3);
+                //RFU: api.internal.system.run("rm /tmp/GBOPERATOR.rommd5");
+                //remove cartridge also and stop timer to find roms/saves from GBOPERATOR
+                dialogBoxGBOPERATORTimer.cartridge_plugged = false;
+                dialogBoxGBOPERATORTimer.stop();
+                //remove potential previous files about rom
+                api.internal.system.run("rm /tmp/GBOPERATOR.romcrc32");
+                api.internal.system.run("rm /tmp/GBOPERATOR.readflag");
+                //for message in dialog box
+                gameCartridge = qsTr("game removed");
+                //to set data of game
+                gameCartridge_region = "";
+                gameCartridge_state = "disconnected";
+                gameCartridge_name = "";
+            }
         }
         function onEventLoadingStarted() {
             //console.log("onEventLoadingStarted()");

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -745,13 +745,13 @@ Window {
         function onAccept() {
             content.focus = true;            
             //copy save game from cartridge to saves "share" directory
-            //For usbnes case (using nes system only and one file name for sav)
             var romcrc32 = "";
             var targetedSave = "";
             var targetedRom = "";
             var existingSave = "";
 
-            if(gameCartridge_save.includes("rom.sav") && api.internal.recalbox.getBoolParameter("dumpers.usbnes.movesave",false)){
+            //For usbnes case (using nes system only and one file name for sav)
+            if(gameCartridge_save.includes("rom.sav") && (gameCartridge_dumper === "usbnes") && api.internal.recalbox.getBoolParameter("dumpers.usbnes.movesave",false)){
                 //get crc32 to ahve it in name of files as reference to improve unicity
                 romcrc32 = api.internal.system.run("cat /tmp/USBNES.romcrc32 | tr -d '\\n' | tr -d '\\r'");
                 //rename .sav to .srm to be compatible with retroarch cores and need to have same name than rom ;-)
@@ -770,10 +770,14 @@ Window {
                 //need to reset rom full path in this case
                 api.internal.singleplay.setFile(targetedRom);
             }
-            //For retrode case (using multiple systems) and not as usbnes ;-)
-            else if((gameCartridge_save !== "") & !gameCartridge_save.includes("rom.sav") && api.internal.recalbox.getBoolParameter("dumpers.retrode.movesave",false)){
+            //For retrode & gb operator case (using multiple systems) and not as usbnes ;-)
+            else if((gameCartridge_save !== "")
+                    && ( ((gameCartridge_dumper === "retrode") && api.internal.recalbox.getBoolParameter("dumpers.retrode.movesave",false))
+                    ||   ((gameCartridge_dumper === "gboperator") && api.internal.recalbox.getBoolParameter("dumpers.gboperator.movesave",false)) )
+                    ){
                 //get crc32 to ahve it in name of files as reference to improve unicity
-                romcrc32 = api.internal.system.run("cat /tmp/RETRODE.romcrc32 | tr -d '\\n' | tr -d '\\r'");
+                if(gameCartridge_dumper === "retrode") romcrc32 = api.internal.system.run("cat /tmp/RETRODE.romcrc32 | tr -d '\\n' | tr -d '\\r'");
+                if(gameCartridge_dumper === "gboperator") romcrc32 = api.internal.system.run("cat /tmp/GBOPERATOR.romcrc32 | tr -d '\\n' | tr -d '\\r'");
                 //copy with existing extension for the moment to retroarch cores and need to have same name than rom but just adding CRC32 ;-)
                 var resultArray = gameCartridge_rom.split("/");
                 var filename = resultArray[resultArray.length -1]; // Get the last component of the path
@@ -839,6 +843,7 @@ Window {
     property string gameCartridge_crc32: "" //use for SNES/SFC for the moment
     property string gameCartridge_save: "" //to know file path of save file
     property string gameCartridge_rom: "" //to know file path of rom file
+    property string gameCartridge_dumper: "" //to store name of dumper for later in process
 
     property string usbnesVersion: "" //to store version at mount
     property string retrodeVersion: "" //to store version at mount
@@ -914,7 +919,7 @@ Window {
                     //console.log("USBNES: previousromcrc32 - ", previousromcrc32)
                     //generate crc32 of the rom detected (including complete path of rom) to be able to compare it with previous one
                     //(don't try to match with screenscrapper one where header is added and/or done on zip file)
-                    var romcrc32 = api.internal.system.run("crc32 " + mountpoint + "/rom.nes | tr -d '\\n' | tr -d '\\r'");
+                    var romcrc32 = api.internal.system.run("crc32 " + mountpoint + "/rom.nes | tr -d '\\n' | tr -d '\\r'").split(" ")[0];
                     //console.log("USBNES: romcrc32 - ", romcrc32)
                     if((parseInt(romsize) > 16)){
                         cartridge_plugged = true;
@@ -931,7 +936,7 @@ Window {
                         //set system to select to run this rom
                         api.internal.singleplay.setSystem("nes"); //using shortName
                         //store new crc32 (including complete path of rom) and store it for the moment
-                        api.internal.system.run("echo '" + romcrc32 + "' | tr -d '\\n' | tr -d '\\r' > /tmp/USBNES.romcrc32");
+                        api.internal.system.run("echo \"" + romcrc32.split(" ")[0] + "\" | tr -d '\\n' | tr -d '\\r' > /tmp/USBNES.romcrc32");
                         //RFU: generate md5 (including complete path of rom) and store it for the moment
                         //api.internal.system.run("md5sum " + mountpoint + "/rom.nes | tr -d '\\n' | tr -d '\\r' > /tmp/USBNES.rommd5");
                         //calculate sha1 for PRG-ROM/SHR-ROM (don't try to match with screenscrapper one where it's done on full .nes/.zip file and including header)
@@ -1032,6 +1037,7 @@ Window {
                         }
 
                         //propose cartridge dialog box in this case
+                        gameCartridge_dumper = "usbnes";
                         cartridgeDialogBoxLoader.visible = true; //to show
                         cartridgeDialogBoxLoader.focus = true; //to have focus
                     }
@@ -1040,6 +1046,7 @@ Window {
                         //remove potential previous files about rom
                         api.internal.system.run("rm /tmp/USBNES.romcrc32");
                         //RFU: api.internal.system.run("rm /tmp/USBNES.rommd5");
+                        gameCartridge_dumper = "";
                         cartridgeDialogBoxLoader.focus = false; //to unfocus if displayed
                         cartridgeDialogBoxLoader.visible = false; //to hide if displayed
                         //show popup to say that game has been removed
@@ -1052,6 +1059,7 @@ Window {
                         gameCartridge_name = "";
                     }
                     else if((parseInt(romsize) <= 16)){
+                        gameCartridge_dumper = "";
                         cartridgeDialogBoxLoader.focus = false; //to unfocus if displayed
                         cartridgeDialogBoxLoader.visible = false; //to hide if displayed
                         //show popup to alert that we didn't detected the game
@@ -1128,6 +1136,7 @@ Window {
                     //remove potential previous files about rom
                     api.internal.system.run("rm /tmp/RETRODE.romcrc32");
                     //RFU: api.internal.system.run("rm /tmp/RETRODE.rommd5");
+                    gameCartridge_dumper = "";
                     cartridgeDialogBoxLoader.focus = false; //to unfocus if displayed
                     cartridgeDialogBoxLoader.visible = false; //to hide if displayed
                     //show popup to say that game has been removed
@@ -1140,6 +1149,7 @@ Window {
                     gameCartridge_name = "";
                 }
                 else if(!readflag.includes("pixl-read")){
+                    gameCartridge_dumper = "";
                     cartridgeDialogBoxLoader.focus = false; //to unfocus if displayed
                     cartridgeDialogBoxLoader.visible = false; //to hide if displayed
                     //show popup to alert that we didn't detected the game
@@ -1191,7 +1201,7 @@ Window {
                 var previousromcrc32 = api.internal.system.run("cat /tmp/RETRODE.romcrc32 | tr -d '\\n' | tr -d '\\r'");
                 //console.log("RETRODE: previousromcrc32 - ", previousromcrc32)
                 //generate crc32 of the rom detected (including complete path of rom) to be able to compare it with previous one
-                var romcrc32 = api.internal.system.run("crc32 " + fileFound + " | tr -d '\\n' | tr -d '\\r'");
+                var romcrc32 = api.internal.system.run("crc32 " + fileFound + " | tr -d '\\n' | tr -d '\\r'").split(" ")[0];
                 //console.log("RETRODE: romcrc32 - ", romcrc32)
                 if(romcrc32 === previousromcrc32){
                     gameCartridge_state = "reloaded";
@@ -1206,7 +1216,7 @@ Window {
                 //set system to select to run this rom
                 api.internal.singleplay.setSystem(systemFound.split("|")[0]); //using shortName or take first one if several use the same extension
                 //store new crc32 (including complete path of rom) and store it for the moment
-                api.internal.system.run("echo '" + romcrc32 + "' | tr -d '\\n' | tr -d '\\r' > /tmp/RETRODE.romcrc32");
+                api.internal.system.run("echo \"" + romcrc32.split(" ")[0] + "\" | tr -d '\\n' | tr -d '\\r' > /tmp/RETRODE.romcrc32");
                 //RFU: generate md5 (including complete path of rom) and store it for the moment
                 //api.internal.system.run("md5sum " + mountpoint + "/rom.nes | tr -d '\\n' | tr -d '\\r' > /tmp/RETRODE.rommd5");
                 //get info from file name (first part)
@@ -1248,7 +1258,7 @@ Window {
                             api.internal.system.run("echo 'GAME TITLE;SYSTEM;WORKS;SAVE FOUND;CRC32 FILE CHECKSUM;DUMPER VERSION;WHEN;COMMENT' >> /recalbox/share/roms/retrode.romlist.csv");
                         }
                         var existingRom = ""
-                        existingRom = api.internal.system.run("grep -i " + romcrc32 + " /recalbox/share/roms/retrode.romlist.csv | tr -d '\\n' | tr -d '\\r'");
+                        existingRom = api.internal.system.run("grep -i " + romcrc32.split(" ")[0] + " /recalbox/share/roms/retrode.romlist.csv | tr -d '\\n' | tr -d '\\r'");
                         //console.log("existingRom  - ",existingRom);
                         if(existingRom === ""){
                             //format GAME TITLE,SYSTEM,WORKS,SAVE FOUND;CRC32 FILE CHECKSUM,DUMPER VERSION,WHEN,COMMENT
@@ -1283,6 +1293,7 @@ Window {
                     }
                 }
                 //propose cartridge dialog box in this case
+                gameCartridge_dumper = "retrode";
                 cartridgeDialogBoxLoader.visible = true; //to show
                 cartridgeDialogBoxLoader.focus = true; //to have focus
                 console.log("RETRODE: gameCartridge (from file name) - ", gameCartridge);
@@ -1335,9 +1346,9 @@ Window {
                     //generate crc32 of the rom detected (including complete path of rom) to be able to compare it with previous one
                     //(don't try to match with screenscrapper one where header is added and/or done on zip file)
                     //console.log("GBOPERATOR: crc32 \"" + mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
-                    var romcrc32 = api.internal.system.run("crc32 \"" + mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
-                    //console.log("GBOPERATOR: romcrc32:", romcrc32)
-                    //console.log("GBOPERATOR: parseInt(romsize):", parseInt(romsize).toString())
+                    var romcrc32 = api.internal.system.run("crc32 \"" + mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'").split(" ")[0];
+                    console.log("GBOPERATOR: romcrc32:", romcrc32)
+                    console.log("GBOPERATOR: parseInt(romsize):", parseInt(romsize).toString())
                     if((parseInt(romsize) >= 32768)){
                         cartridge_plugged = true;
                         if(romcrc32 === previousromcrc32){
@@ -1353,7 +1364,7 @@ Window {
                         //set system to select to run this rom
                         api.internal.singleplay.setSystem(system); //using shortName
                         //store new crc32 (including complete path of rom) and store it for the moment
-                        api.internal.system.run("echo '" + romcrc32 + "' | tr -d '\\n' | tr -d '\\r' > /tmp/GBOPERATOR.romcrc32");
+                        api.internal.system.run("echo \"" + romcrc32.split(" ")[0] + "\" | tr -d '\\n' | tr -d '\\r' > /tmp/GBOPERATOR.romcrc32");
                         //RFU: generate md5 (including complete path of rom) and store it for the moment
                         //api.internal.system.run("md5sum " + mountpoint + "/rom.nes | tr -d '\\n' | tr -d '\\r' > /tmp/GBOPERATOR.rommd5");
                         if(rominfo !== ""){
@@ -1384,7 +1395,7 @@ Window {
                                 }
 
                                 var existingRom = ""
-                                existingRom = api.internal.system.run("grep -i " + romcrc32 + " /recalbox/share/roms/usb-nes.romlist.csv | tr -d '\\n' | tr -d '\\r'");
+                                existingRom = api.internal.system.run("grep -i " + romcrc32.split(" ")[0] + " /recalbox/share/roms/gboperator.romlist.csv | tr -d '\\n' | tr -d '\\r'");
                                 //console.log("GBOPERATOR: existingRom  - ",existingRom);
                                 if(existingRom === ""){
                                     //format GAME TITLE,GAME ID,WORKS,SAVE FOUND;ROM CRC32,DUMPER VERSION,DUMPER HEADER HEXA,DUMPER HEADER ASCII,WHEN,COMMENT
@@ -1437,6 +1448,7 @@ Window {
                         }
 
                         //propose cartridge dialog box in this case
+                        gameCartridge_dumper = "gboperator";
                         cartridgeDialogBoxLoader.visible = true; //to show
                         cartridgeDialogBoxLoader.focus = true; //to have focus
                     }

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1380,14 +1380,14 @@ Window {
                                 existingFile = api.internal.system.run("ls /recalbox/share/roms/gboperator.romlist.csv 2>/dev/null | tr -d '\\n' | tr -d '\\r'");
                                 if(!existingFile.includes("gboperator.romlist.csv")){
                                     //if no file exists, let create it with column titles
-                                    api.internal.system.run("echo 'GAME TITLE;WORKS;SAVE FOUND;ROM CRC32;DUMPER VERSION;WHEN;COMMENT' >> /recalbox/share/roms/gboperator.romlist.csv");
+                                    api.internal.system.run("echo 'GAME TITLE;EPILOGUEID(GB/GBC)/GAMEID(GBA);WORKS;SAVE FOUND;ROM CRC32;DUMPER VERSION;DUMPER HEADER HEXA;DUMPER HEADER ASCII;WHEN;COMMENT' >> /recalbox/share/roms/gboperator.romlist.csv");
                                 }
 
                                 var existingRom = ""
                                 existingRom = api.internal.system.run("grep -i " + romcrc32 + " /recalbox/share/roms/usb-nes.romlist.csv | tr -d '\\n' | tr -d '\\r'");
                                 //console.log("GBOPERATOR: existingRom  - ",existingRom);
                                 if(existingRom === ""){
-                                    //format GAME TITLE,WORKS,SAVE FOUND;ROM CRC32,DUMPER VERSION,WHEN,COMMENT
+                                    //format GAME TITLE,GAME ID,WORKS,SAVE FOUND;ROM CRC32,DUMPER VERSION,DUMPER HEADER HEXA,DUMPER HEADER ASCII,WHEN,COMMENT
                                     var now = new Date();
                                     var formattedDateTime = now.toString("yyyy-MM-dd hh:mm:ss");
                                     //console.log("GBOPERATOR: Formatted date and time - ", formattedDateTime);
@@ -1395,8 +1395,13 @@ Window {
                                         //read GB OPERATOR version and store it in global variable
                                         gboperatorVersion = "1.0" // fix version for the moment, need to investigate if possible to have it from GB OPERATOR ?!
                                     }
-                                    //console.log('GBOPERATOR: echo "' + rominfo + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
-                                    api.internal.system.run('echo "' + rominfo + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
+                                    //get gb operator epilogueid(GB/GBC)/gameid(GBA)
+                                    var gameid = api.internal.system.run("cat /tmp/GBOPERATOR.gameid | tr -d '\\n' | tr -d '\\r'");
+                                    //get also gb operator header info
+                                    var gboperatorHeaderHexa = api.internal.system.run("cat /tmp/GBOPERATOR.hexaheader | tr -d '\\n' | tr -d '\\r'");
+                                    var gboperatorHeaderAscii = api.internal.system.run("cat /tmp/GBOPERATOR.asciiheader | tr -d '\\n' | tr -d '\\r'");
+                                    //console.log('GBOPERATOR: echo "' + rominfo + ';' + gameid + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + gboperatorheaderhexa + ';' + gboperatorheaderascii + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
+                                    api.internal.system.run('echo "' + rominfo + ';' + gameid + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + gboperatorHeaderHexa + ';' + gboperatorHeaderAscii + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
 
                                 }
                             }

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1423,7 +1423,7 @@ Window {
                             gameCartridge_name = rominfo;
                             //dump of rom if request
                             if(api.internal.recalbox.getBoolParameter("dumpers.gboperator.savedump",false)){
-                                var targetedDump = "/recalbox/share/dumps/" + gameCartridge_name  + " [" + romcrc32.split(' ')[0] + "].gb";
+                                var targetedDump = "/recalbox/share/dumps/" + gameCartridge_name  + " [" + romcrc32.split(' ')[0] + "]." + gameCartridge_system;
                                 //console.log("GBOPERATOR: ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                                 var existingDump = api.internal.system.run("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                                 //console.log("GBOPERATOR: existingDump  - ",existingDump);

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -840,6 +840,7 @@ Window {
 
     property string usbnesVersion: "" //to store version at mount
     property string retrodeVersion: "" //to store version at mount
+    property string gboperatorVersion: "" //to store version (RFU)
 
     Component {
         id: cartridgeDialogBox
@@ -1288,6 +1289,192 @@ Window {
                 //console.log("RETRODE gameCartridge_crc32 (as in gamelist for snes): ", gameCartridge_crc32);
                 //console.log("RETRODE gameCartridge_state : ", gameCartridge_state);
                 //console.log("RETRODE gameCartridge_name (name extracted to help for search in gamelists): ", gameCartridge_name);
+            }
+        }
+    }
+
+    // Timer to show the dialog box for cartridge (GB OPERATOR)
+    Timer {
+        id: dialogBoxGBOPERATORTimer
+        interval: 5000
+        triggeredOnStart: false
+        repeat: true
+        running: (splashScreen.focus) ? false : true
+        property bool cartridge_plugged: false
+        onTriggered: {
+            if (!api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false)){
+                //do nothing if not enabled but we keep timer running for detection
+                return;
+            }
+            var mountpoint = "/tmp"; //use tmp directory for gboperator because no mountpoint exists in this case
+            //console.log("gboperator "virtual" mountpoint : ", mountpoint)
+            if(mountpoint.includes("/tmp")) { //stupid test just to keep same structucode than USBNES ;-)
+                //console.log("GB OPERATOR cartridge plugged: ", cartridge_plugged)
+                //check any change ?
+                var readflag = api.internal.system.run("cat " + mountpoint + "/pixl-read.flag" + " | tr -d '\\n' | tr -d '\\r'");
+                //console.log("GB OPERATOR readflag: ", readflag);
+                if(readflag !== "true"){
+                    //get size of the rom detected
+                    var romsize = api.internal.system.run("wc -c "+ mountpoint + "/rom.gb  | tr -d '\\n' | tr -d '\\r'");
+                    //console.log("GB OPERATOR romsize: ", romsize)
+                    //get previous crc32 if exists (including complete path of rom) to be able to compare it with previous one
+                    var previousromcrc32 = api.internal.system.run("cat /tmp/GBOPERATOR.romcrc32 | tr -d '\\n' | tr -d '\\r'");
+                    //console.log("GB OPERATOR previousromcrc32: ", previousromcrc32)
+                    //generate crc32 of the rom detected (including complete path of rom) to be able to compare it with previous one
+                    //(don't try to match with screenscrapper one where header is added and/or done on zip file)
+                    var romcrc32 = api.internal.system.run("crc32 " + mountpoint + "/rom.gb | tr -d '\\n' | tr -d '\\r'");
+                    //console.log("GB OPERATOR romcrc32: ", romcrc32)
+                    if((parseInt(romsize) > 16)){
+                        cartridge_plugged = true;
+                        if(romcrc32 === previousromcrc32){
+                            gameCartridge_state = "reloaded";
+                            //show popup to say that is a reset
+                            apiconnection.onShowPopup(qsTr("Video game cartridge reader"), qsTr("GB OPERATOR cartridge reloaded"),"",2);
+                        }
+                        //just set "cartridge" as title of this game (optional)
+                        api.internal.singleplay.setTitle("cartridge");
+                        //set rom full path
+                        gameCartridge_rom = mountpoint + "/rom.gb";
+                        api.internal.singleplay.setFile(gameCartridge_rom);
+                        //set system to select to run this rom
+                        api.internal.singleplay.setSystem("gb"); //using shortName
+                        //store new crc32 (including complete path of rom) and store it for the moment
+                        api.internal.system.run("echo '" + romcrc32 + "' | tr -d '\\n' | tr -d '\\r' > /tmp/GBOPERATOR.romcrc32");
+                        //RFU: generate md5 (including complete path of rom) and store it for the moment
+                        //api.internal.system.run("md5sum " + mountpoint + "/rom.nes | tr -d '\\n' | tr -d '\\r' > /tmp/GBOPERATOR.rommd5");
+                        var rominfo = api.internal.system.run("cat /tmp/GBOPERATOR.gamefound | tr -d '\\n' | tr -d '\\r'");
+                        //console.log("GB OPERATOR rominfo: ", rominfo);
+                        if(rominfo !== ""){
+                            //check also if sav game exist
+                            var savinfo=api.internal.system.run("ls "+ mountpoint + "/rom.sav 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                            //console.log("GB OPERATOR savinfo: ", savinfo);
+                            var savinfoflag = "N";
+                            gameCartridge_save = "";
+                            if(savinfo !== ""){
+                                savinfoflag = "Y";
+                                //just communicate that sav is available
+                                gameCartridge_save = mountpoint + "/rom.sav";
+                            }
+                            gameCartridge_state = "identified";
+                            gameCartridge = rominfo;
+                            //rominfo.split('\\')[1] + " (" + rominfo.split('\\')[0].split(" ")[1] + ")" + " - " + rominfo.split('\\')[0].split(" ")[0];
+                            //to take first part that could contain type (licenced/playchoise/Vs. System/unlicensed...) and region (optionaly: PAL, North America, Japan, China, Taiwan & HongKong, ElseWhere, South Korea...)
+                            //we will manage only cartdridge format and what we ahve with no-intro ;-)
+                            var type_region = rominfo.split('\\')[0];
+                            //console.log("GB OPERATOR type_region: ", type_region);
+                            gameCartridge_type = type_region.split(' ')[0];
+                            //console.log("GB OPERATOR gameCartridge_type: ", gameCartridge_type);
+                            gameCartridge_region = type_region.replace(gameCartridge_type,"");
+                            //finally we trim region here for later
+                            var regex = RegExp("^\\s*(.*?)\\s*$");
+                            gameCartridge_region = gameCartridge_region.replace(regex, "$1");
+                            //console.log("GB OPERATOR region: '",gameCartridge_region,"'");
+                            if(gameCartridge_region !== ""){
+                                var region_index = getRegionIndex(gameCartridge_region);
+                                if(region_index !== -1){
+                                    gameCartridge_region_regex = regionSSModel.get(region_index).regex;
+                                }
+                                else gameCartridge_region_regex = "";
+                            }
+                            else gameCartridge_region_regex = "";
+                            //check if option to save rominfo/crc32 is requested
+                            if(api.internal.recalbox.getBoolParameter("dumpers.gboperator.romlist",false)){
+                                var existingFile = ""
+                                existingFile = api.internal.system.run("ls /recalbox/share/roms/gboperator.romlist.csv 2>/dev/null | tr -d '\\n' | tr -d '\\r'");
+                                if(!existingFile.includes("gboperator.romlist.csv")){
+                                    //if no file exists, let create it with column titles
+                                    api.internal.system.run("echo 'GAME TITLE;REGION;TYPE;WORKS;SAVE FOUND;ROM CRC32;DUMPER VERSION;WHEN;COMMENT' >> /recalbox/share/roms/gboperator.romlist.csv");
+                                }
+
+                                var existingRom = ""
+                                existingRom = api.internal.system.run("grep -i " + romcrc32 + " /recalbox/share/roms/usb-nes.romlist.csv | tr -d '\\n' | tr -d '\\r'");
+                                //console.log("existingRom : ",existingRom);
+                                if(existingRom === ""){
+                                    //format GAME TITLE,REGION,TYPE,WORKS,SAVE FOUND;ROM CRC32,DUMPER VERSION,WHEN,COMMENT
+                                    var now = new Date();
+                                    var formattedDateTime = now.toString("yyyy-MM-dd hh:mm:ss");
+                                    //console.log("Formatted date and time:", formattedDateTime);
+                                    if(gboperatorVersion === ""){
+                                        //read GB OPERATOR version and store it in global variable
+                                        gboperatorVersion = "1.0" // fix version for the moment, need to investigate if possible to have it from GB OPERATOR ?!
+                                    }
+                                    //console.log('echo "' + rominfo.split('\\')[1] + ';' + region + ';' + gameCartridge_type + ';' +  'Y' + ';' + savinfoflag + ';' +  romsha1 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
+                                    api.internal.system.run('echo "' + rominfo.split('\\')[1] + ';' + region + ';' + gameCartridge_type + ';' +  'Y' + ';' + savinfoflag + ';' +  romsha1 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
+
+                                }
+                            }
+                            gameCartridge_system = "gb";
+                            //to do last because will trig changes
+                            gameCartridge_crc32 = "";
+                            //remove data between [] and () in name as: (rev 1), (rev 2)
+                            regex = /\([^()]*\)|\[[^\]]*\]/;
+                            gameCartridge_name = rominfo.split('\\')[1].replace(regex, "");
+                            //dump of rom if request
+                            if(api.internal.recalbox.getBoolParameter("dumpers.gboperator.savedump",false)){
+                                var targetedDump = "/recalbox/share/dumps/" + gameCartridge_name + " (" + gameCartridge_region + ")" + " (" + gameCartridge_type + ") [" + romcrc32.split(' ')[0] + "].gb";
+                                //console.log("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                                var existingDump = api.internal.system.run("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                                //console.log("existingDump : ",existingDump);
+                                //for the moment: we don't dump rom if already exists in dumps directory / no proposal to erase in this case
+                                //manual move/erase to do in share dumps directory in this case
+                                if(!existingDump.includes("/recalbox/share/dumps/")){
+                                    //copy of rom as dump
+                                    //console.log("cp '" + gameCartridge_rom + "' '" + targetedDump + "'");
+                                    api.internal.system.run("cp '" + gameCartridge_rom + "' '" + targetedDump + "'");
+                                }
+                            }
+                        }
+                        else{
+                            //for message in dialog box
+                            gameCartridge = qsTr("unknown game / not recognized");
+                            //to set data of game
+                            gameCartridge_region = "";
+                            gameCartridge_system = "gb";
+                            gameCartridge_state = "unknown";
+                            gameCartridge_crc32 = "";
+                            gameCartridge_name = "";
+                        }
+
+                        //propose cartridge dialog box in this case
+                        cartridgeDialogBoxLoader.visible = true; //to show
+                        cartridgeDialogBoxLoader.focus = true; //to have focus
+                    }
+                    else if((parseInt(romsize) <= 16) && (cartridge_plugged === true)){
+                        cartridge_plugged = false;
+                        //remove potential previous files about rom
+                        api.internal.system.run("rm /tmp/USBNES.romcrc32");
+                        //RFU: api.internal.system.run("rm /tmp/USBNES.rommd5");
+                        cartridgeDialogBoxLoader.focus = false; //to unfocus if displayed
+                        cartridgeDialogBoxLoader.visible = false; //to hide if displayed
+                        //show popup to say that game has been removed
+                        apiconnection.onShowPopup(qsTr("Video game cartridge reader"), qsTr("USB-NES cartridge unplugged"),"",3);
+                        gameCartridge = "";
+                        gameCartridge_region = "";
+                        gameCartridge_system = "";
+                        gameCartridge_state = "unplugged";
+                        gameCartridge_crc32 = "";
+                        gameCartridge_name = "";
+                    }
+                    else if((parseInt(romsize) <= 16)){
+                        cartridgeDialogBoxLoader.focus = false; //to unfocus if displayed
+                        cartridgeDialogBoxLoader.visible = false; //to hide if displayed
+                        //show popup to alert that we didn't detected the game
+                        apiconnection.onShowPopup(qsTr("Video game cartridge reader"), qsTr("USB-NES no cartridge detected"),"",3);
+                        gameCartridge = "";
+                        gameCartridge_region = "";
+                        gameCartridge_system = "";
+                        gameCartridge_state = "";
+                        gameCartridge_crc32 = "";
+                        gameCartridge_name = "";
+                    }
+                    //console.log("USB-NES gameCartridge (full description from NESDB 2.0) : ", gameCartridge);
+                    //console.log("USB-NES gameCartridge_region (no-intro regions) : ", gameCartridge_region);
+                    //console.log("USB-NES gameCartridge_system (pixL system shortname): ", gameCartridge_system);
+                    //console.log("USB-NES gameCartridge_state : ", gameCartridge_state);
+                    //console.log("USB-NES gameCartridge_name (name extracted to help for search in gamelists): ", gameCartridge_name);
+                    //set read.flag to "true"
+                    api.internal.system.run("echo '" + true + "' | tr -d '\\n' | tr -d '\\r' > " + mountpoint + "/pixl-read.flag");
+                }
             }
         }
     }

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -749,26 +749,36 @@ Window {
             var targetedSave = "";
             var targetedRom = "";
             var existingSave = "";
+            var coreLongName;
 
             //For usbnes case (using nes system only and one file name for sav)
             if(gameCartridge_save.includes("rom.sav") && (gameCartridge_dumper === "usbnes") && api.internal.recalbox.getBoolParameter("dumpers.usbnes.movesave",false)){
                 //get crc32 to ahve it in name of files as reference to improve unicity
                 romcrc32 = api.internal.system.run("cat /tmp/USBNES.romcrc32 | tr -d '\\n' | tr -d '\\r'");
-                //rename .sav to .srm to be compatible with retroarch cores and need to have same name than rom ;-)
-                targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + gameCartridge_name + " (" + gameCartridge_region + ")" + " (" + gameCartridge_type + ") [" + romcrc32.split(' ')[0] + "].srm";
+
                 targetedRom = "/recalbox/share/extractions/" + gameCartridge_name + " (" + gameCartridge_region + ")" + " (" + gameCartridge_type + ") [" + romcrc32.split(' ')[0] + "].nes";
-                existingSave = api.internal.system.run("ls \""+ targetedSave + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                //for the moment: we don't recopy save if already exists for this rom / no proposal to erase in this case
-                //manual move/erase to do in share saves directory in this case
-                if(!existingSave.includes("/recalbox/share/saves/")){
-                    //copy of save
-                    api.internal.system.run("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
-                }
                 //mandatory copy of rom in /extractions to be able to rename rom (.nes) and to match with targeted save file (.srm) (we will erase in this case if already exists)
                 //copy of rom
                 api.internal.system.run("cp \"" + gameCartridge_rom + "\" \"" + targetedRom + "\"");
                 //need to reset rom full path in this case
                 api.internal.singleplay.setFile(targetedRom);
+
+                //for the moment: we don't recopy save if already exists for this rom / no proposal to erase in this case
+                if(api.internal.singleplay.getEmulatorName() === "libretro"){
+                    coreLongName = api.internal.singleplay.getCoreLongName();
+                    //rename .sav to .srm to be compatible with retroarch cores and need to have same name than rom ;-)
+                    targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + coreLongName + "/" + gameCartridge_name + " (" + gameCartridge_region + ")" + " (" + gameCartridge_type + ") [" + romcrc32.split(' ')[0] + "].srm";
+                }
+                else{
+                    //rename .sav to .srm to be compatible with retroarch cores and need to have same name than rom ;-)
+                    targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + gameCartridge_name + " (" + gameCartridge_region + ")" + " (" + gameCartridge_type + ") [" + romcrc32.split(' ')[0] + "].srm";
+                }
+                existingSave = api.internal.system.run("ls \""+ targetedSave + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                //manual move/erase to do in share saves directory in this case
+                if(!existingSave.includes("/recalbox/share/saves/")){
+                    //copy of save
+                    api.internal.system.run("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
+                }
             }
             //For retrode & gb operator case (using multiple systems) and not as usbnes ;-)
             else if((gameCartridge_save !== "")
@@ -796,6 +806,7 @@ Window {
                 filename = resultArray[resultArray.length -1]; // Get the last component of the path
                 //force every save file to use .srm extension for the moment when we move it and use it with in retroarch
                 var savExt = ".srm";
+
                 //RFU
                 // Apply the regular expression to the file name
                 //match = regex.exec(filename);
@@ -806,22 +817,30 @@ Window {
                 //    savName = match[1];
                 //    savExt = match[2];
                 //}
-                targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + romName + " [" + romcrc32.split(' ')[0] + "]" + savExt;
+
                 targetedRom = "/recalbox/share/extractions/" + romName + " [" + romcrc32.split(' ')[0] + "]" + romExt;
-                existingSave = api.internal.system.run("ls \""+ targetedSave + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                //for the moment: we don't recopy save if already exists for this rom / no proposal to erase in this case
-                //manual move/erase to do in share saves directory in this case
-                if(!existingSave.includes("/recalbox/share/saves/")){
-                    //copy of save
-                    api.internal.system.run("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
-                }
                 //mandatory copy of rom in /extractions to be able to rename rom nd to match with targeted save file (we will erase in this case if already exists)
                 //copy of rom
                 api.internal.system.run("cp \"" + gameCartridge_rom + "\" \"" + targetedRom + "\"");
                 //need to reset rom full path in this case
                 api.internal.singleplay.setFile(targetedRom);
-            }
 
+                //for the moment: we don't recopy save if already exists for this rom / no proposal to erase in this case
+                if(api.internal.singleplay.getEmulatorName() === "libretro"){
+                    coreLongName = api.internal.singleplay.getCoreLongName();
+                    targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + coreLongName + "/" + romName + " [" + romcrc32.split(' ')[0] + "]" + savExt;
+                }
+                else{
+                    targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + romName + " [" + romcrc32.split(' ')[0] + "]" + savExt;
+                }
+                existingSave = api.internal.system.run("ls \""+ targetedSave + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                //manual move/erase to do in share saves directory in this case
+                if(!existingSave.includes("/recalbox/share/saves/")){
+                    //copy of save
+                    api.internal.system.run("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
+                }
+
+            }
             // connect game to launcher
             api.connectGameFiles(api.internal.singleplay.game);
             // launch this Game

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1571,7 +1571,7 @@ Window {
                 apiconnection.onShowPopup("Video game cartridge reader", "RETRODE removed","",3);
                 //remove potential previous files about rom
                 api.internal.system.run("rm /tmp/RETRODE.romcrc32");
-                api.internal.system.run("rm /tmp/RETRODE.rommd5");
+                //RFU: api.internal.system.run("rm /tmp/RETRODE.rommd5");
                 //remove cartridge also and stop timer to find roms/saves from RETRODE
                 dialogBoxRETRODETimer.cartridge_plugged = false;
                 dialogBoxRETRODETimer.stop();
@@ -1597,7 +1597,7 @@ Window {
                 apiconnection.onShowPopup("Video game cartridge reader", "USB-NES removed","",3);
                 //remove potential previous files about rom
                 api.internal.system.run("rm /tmp/USBNES.romcrc32");
-                api.internal.system.run("rm /tmp/USBNES.rommd5");
+                //RFU: api.internal.system.run("rm /tmp/USBNES.rommd5");
                 //remove cartridge also and stop timer to find roms/saves from USBNES
                 dialogBoxUSBNESTimer.cartridge_plugged = false;
                 dialogBoxUSBNESTimer.stop();
@@ -1636,7 +1636,7 @@ Window {
                 apiconnection.onShowPopup("Video game cartridge reader", "GB OPERATOR removed","",3);
                 //remove potential previous files about rom
                 api.internal.system.run("rm /tmp/GBOPERATOR.romcrc32");
-                api.internal.system.run("rm /tmp/GBOPERATOR.rommd5");
+                //RFU: api.internal.system.run("rm /tmp/GBOPERATOR.rommd5");
                 //remove cartridge also and stop timer to find roms/saves from GBOPERATOR
                 dialogBoxGBOPERATORTimer.cartridge_plugged = false;
                 dialogBoxGBOPERATORTimer.stop();

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -757,16 +757,16 @@ Window {
                 //rename .sav to .srm to be compatible with retroarch cores and need to have same name than rom ;-)
                 targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + gameCartridge_name + " (" + gameCartridge_region + ")" + " (" + gameCartridge_type + ") [" + romcrc32.split(' ')[0] + "].srm";
                 targetedRom = "/recalbox/share/extractions/" + gameCartridge_name + " (" + gameCartridge_region + ")" + " (" + gameCartridge_type + ") [" + romcrc32.split(' ')[0] + "].nes";
-                existingSave = api.internal.system.run("ls '"+ targetedSave + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                existingSave = api.internal.system.run("ls \""+ targetedSave + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                 //for the moment: we don't recopy save if already exists for this rom / no proposal to erase in this case
                 //manual move/erase to do in share saves directory in this case
                 if(!existingSave.includes("/recalbox/share/saves/")){
                     //copy of save
-                    api.internal.system.run("cp '" + gameCartridge_save + "' '" + targetedSave + "'");
+                    api.internal.system.run("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
                 }
                 //mandatory copy of rom in /extractions to be able to rename rom (.nes) and to match with targeted save file (.srm) (we will erase in this case if already exists)
                 //copy of rom
-                api.internal.system.run("cp '" + gameCartridge_rom + "' '" + targetedRom + "'");
+                api.internal.system.run("cp \"" + gameCartridge_rom + "\" \"" + targetedRom + "\"");
                 //need to reset rom full path in this case
                 api.internal.singleplay.setFile(targetedRom);
             }
@@ -808,16 +808,16 @@ Window {
                 //}
                 targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + romName + " [" + romcrc32.split(' ')[0] + "]" + savExt;
                 targetedRom = "/recalbox/share/extractions/" + romName + " [" + romcrc32.split(' ')[0] + "]" + romExt;
-                existingSave = api.internal.system.run("ls '"+ targetedSave + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                existingSave = api.internal.system.run("ls \""+ targetedSave + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                 //for the moment: we don't recopy save if already exists for this rom / no proposal to erase in this case
                 //manual move/erase to do in share saves directory in this case
                 if(!existingSave.includes("/recalbox/share/saves/")){
                     //copy of save
-                    api.internal.system.run("cp '" + gameCartridge_save + "' '" + targetedSave + "'");
+                    api.internal.system.run("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
                 }
                 //mandatory copy of rom in /extractions to be able to rename rom nd to match with targeted save file (we will erase in this case if already exists)
                 //copy of rom
-                api.internal.system.run("cp '" + gameCartridge_rom + "' '" + targetedRom + "'");
+                api.internal.system.run("cp \"" + gameCartridge_rom + "\" \"" + targetedRom + "\"");
                 //need to reset rom full path in this case
                 api.internal.singleplay.setFile(targetedRom);
             }
@@ -1013,15 +1013,15 @@ Window {
                             //dump of rom if request
                             if(api.internal.recalbox.getBoolParameter("dumpers.usbnes.savedump",false)){
                                 var targetedDump = "/recalbox/share/dumps/" + gameCartridge_name + " (" + gameCartridge_region + ")" + " (" + gameCartridge_type + ") [" + romcrc32.split(' ')[0] + "].nes";
-                                //console.log("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                                var existingDump = api.internal.system.run("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                                //console.log("ls \""+ targetedDump + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                                var existingDump = api.internal.system.run("ls \""+ targetedDump + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                                 //console.log("existingDump  - ",existingDump);
                                 //for the moment: we don't dump rom if already exists in dumps directory / no proposal to erase in this case
                                 //manual move/erase to do in share dumps directory in this case
                                 if(!existingDump.includes("/recalbox/share/dumps/")){
                                     //copy of rom as dump
-                                    //console.log("cp '" + gameCartridge_rom + "' '" + targetedDump + "'");
-                                    api.internal.system.run("cp '" + gameCartridge_rom + "' '" + targetedDump + "'");
+                                    //console.log("cp \"" + gameCartridge_rom + "\" \"" + targetedDump + "\"");
+                                    api.internal.system.run("cp \"" + gameCartridge_rom + "\" \"" + targetedDump + "\"");
                                 }
                             }
                         }
@@ -1280,8 +1280,8 @@ Window {
                     //dump of rom if request
                     if(api.internal.recalbox.getBoolParameter("dumpers.retrode.savedump",false)){
                         var targetedDump = "/recalbox/share/dumps/" + rominfo + " [" + gameCartridge_crc32 + "]." + romExt;
-                        //console.log("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                        var existingDump = api.internal.system.run("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                        //console.log("ls \""+ targetedDump + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                        var existingDump = api.internal.system.run("ls \""+ targetedDump + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                         //console.log("existingDump  - ",existingDump);
                         //for the moment: we don't dump rom if already exists in dumps directory / no proposal to erase in this case
                         //manual move/erase to do in share dumps directory in this case
@@ -1419,20 +1419,20 @@ Window {
                             gameCartridge_system = system;
                             //to do last because will trig changes
                             gameCartridge_crc32 = romcrc32.split(" ")[0];//need to take first part only because file name/path is inlcuded in result of CRC32 calculation
-                            //console.log("GBOPERATOR: gameCartridge_crc32 - ", gameCartridge_crc32);
+                            console.log("GBOPERATOR: gameCartridge_crc32 - ", gameCartridge_crc32);
                             gameCartridge_name = rominfo;
                             //dump of rom if request
                             if(api.internal.recalbox.getBoolParameter("dumpers.gboperator.savedump",false)){
                                 var targetedDump = "/recalbox/share/dumps/" + gameCartridge_name  + " [" + romcrc32.split(' ')[0] + "]." + gameCartridge_system;
-                                //console.log("GBOPERATOR: ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                                var existingDump = api.internal.system.run("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                                //console.log("GBOPERATOR: existingDump  - ",existingDump);
+                                console.log("GBOPERATOR: ls \""+ targetedDump + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                                var existingDump = api.internal.system.run("ls \""+ targetedDump + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                                console.log("GBOPERATOR: existingDump  - ",existingDump);
                                 //for the moment: we don't dump rom if already exists in dumps directory / no proposal to erase in this case
                                 //manual move/erase to do in share dumps directory in this case
                                 if(!existingDump.includes("/recalbox/share/dumps/")){
                                     //copy of rom as dump
-                                    //console.log("GBOPERATOR: cp '" + gameCartridge_rom + "' '" + targetedDump + "'");
-                                    api.internal.system.run("cp '" + gameCartridge_rom + "' '" + targetedDump + "'");
+                                    console.log("GBOPERATOR: cp \"" + gameCartridge_rom + "\" \"" + targetedDump + "\"");
+                                    api.internal.system.run("cp \"" + gameCartridge_rom + "\" \"" + targetedDump + "\"");
                                 }
                             }
                         }

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1376,7 +1376,7 @@ Window {
                             if(savinfo !== ""){
                                 savinfoflag = "Y";
                                 //just communicate that sav is available
-                                gameCartridge_save = mountpoint + "/" + romname +".sav";
+                                gameCartridge_save = mountpoint + "/" + rominfo +".sav";
                             }
                             gameCartridge_state = "identified";
                             gameCartridge = rominfo;

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1444,6 +1444,29 @@ Window {
                 apiconnection.onShowPopup("Video game CD-ROM reader", "CD-ROM mounted from " + cdromDevice + " to " + cdromMountpoint,"",3);
                 cdRomDialogBoxTimer.start();
             }
+            // FOR EPILOGUE GB OPERATOR...
+            else if(action === "gboperator-remove" && api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false)){
+                apiconnection.onShowPopup("Video game cartridge reader", "GB OPERATOR removed","",3);
+                //remove potential previous files about rom
+                api.internal.system.run("rm /tmp/GBOPERATOR.romcrc32");
+                api.internal.system.run("rm /tmp/GBOPERATOR.rommd5");
+                //remove cartridge also and stop timer to find roms/saves from GBOPERATOR
+                dialogBoxGBOPERATORTimer.cartridge_plugged = false;
+                dialogBoxGBOPERATORTimer.stop();
+                //for message in dialog box
+                gameCartridge = qsTr("gb operator removed");
+                //to set data of game
+                gameCartridge_region = "";
+                gameCartridge_state = "disconnected";
+                gameCartridge_name = "";
+            }
+            else if(action.includes("gboperator-add") && api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false)){
+                apiconnection.onShowPopup("Video game cartridge reader", "GB Operator plugged","",3);
+                //run timer to find roms/saves from GB Operator
+                dialogBoxGBOPERATORTimer.cartridge_plugged = false;
+                dialogBoxGBOPERATORTimer.start();
+            }
+
         }
         function onEventLoadingStarted() {
             //console.log("onEventLoadingStarted()");

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -1309,34 +1309,35 @@ Window {
                 return;
             }
             var mountpoint = "/tmp"; //use tmp directory for gboperator because no mountpoint exists in this case
-            console.log("gboperator 'virtual' mountpoint : ", mountpoint)
+            //console.log("gboperator 'virtual' mountpoint : ", mountpoint)
             if(mountpoint.includes("/tmp")) { //stupid test just to keep same structucode than USBNES ;-)
-                console.log("GB OPERATOR cartridge plugged: ", cartridge_plugged)
+                //console.log("GB OPERATOR cartridge plugged: ", cartridge_plugged)
                 //check any change ?
                 var readflag = api.internal.system.run("cat " + mountpoint + "/GBOPERATOR.readflag" + " | tr -d '\\n' | tr -d '\\r'");
-                console.log("GB OPERATOR readflag: ", readflag);
+                //console.log("GB OPERATOR readflag: ", readflag);
                 if(readflag !== "true"){
                     //in case of GB operator, the gameinfo contains the ROM file name with extension for the moment
                     var romfile = api.internal.system.run("cat /tmp/GBOPERATOR.gamedumped | tr -d '\\n' | tr -d '\\r'");
                     //just file name without extension for the moment in rominfo
                     var parts = romfile.split(".");
                     var rominfo = parts.slice(0, -1).join(".");
-                    console.log("GB OPERATOR rominfo: ", rominfo);
+                    //console.log("GB OPERATOR rominfo: ", rominfo);
                     //get system from romfile extension (gb or gbc, gba not yet supported)
                     var system =  romfile.split('.').pop();
-                    console.log("GB OPERATOR system: ", system)
+                    //console.log("GB OPERATOR system: ", system)
                     //get size of the rom detected
                     console.log("wc -c \""+ mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
                     var romsize = api.internal.system.run("wc -c \""+ mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
-                    console.log("GB OPERATOR romsize: ", romsize)
+                    //console.log("GB OPERATOR romsize: ", romsize)
                     //get previous crc32 if exists (including complete path of rom) to be able to compare it with previous one
                     var previousromcrc32 = api.internal.system.run("cat /tmp/GBOPERATOR.romcrc32 | tr -d '\\n' | tr -d '\\r'");
-                    console.log("GB OPERATOR previousromcrc32: ", previousromcrc32)
+                    //console.log("GB OPERATOR previousromcrc32: ", previousromcrc32)
                     //generate crc32 of the rom detected (including complete path of rom) to be able to compare it with previous one
                     //(don't try to match with screenscrapper one where header is added and/or done on zip file)
-                    console.log("crc32 \"" + mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
+                    //console.log("crc32 \"" + mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
                     var romcrc32 = api.internal.system.run("crc32 \"" + mountpoint + "/" + romfile + "\" | tr -d '\\n' | tr -d '\\r'");
-                    console.log("GB OPERATOR romcrc32: ", romcrc32)
+                    //console.log("GB OPERATOR romcrc32:", romcrc32)
+                    //console.log("GB OPERATOR parseInt(romsize):", parseInt(romsize).toString())
                     if((parseInt(romsize) >= 32768)){
                         cartridge_plugged = true;
                         if(romcrc32 === previousromcrc32){
@@ -1358,7 +1359,7 @@ Window {
                         if(rominfo !== ""){
                             //check also if sav game exist
                             var savinfo=api.internal.system.run("ls \""+ mountpoint + "/" + rominfo + ".sav\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                            //console.log("GB OPERATOR savinfo: ", savinfo);
+                            console.log("GB OPERATOR savinfo: ", savinfo);
                             var savinfoflag = "N";
                             gameCartridge_save = "";
                             if(savinfo !== ""){
@@ -1368,40 +1369,25 @@ Window {
                             }
                             gameCartridge_state = "identified";
                             gameCartridge = rominfo;
-                            //rominfo.split('\\')[1] + " (" + rominfo.split('\\')[0].split(" ")[1] + ")" + " - " + rominfo.split('\\')[0].split(" ")[0];
-                            //to take first part that could contain type (licenced/playchoise/Vs. System/unlicensed...) and region (optionaly: PAL, North America, Japan, China, Taiwan & HongKong, ElseWhere, South Korea...)
-                            //we will manage only cartdridge format and what we ahve with no-intro ;-)
-                            var type_region = rominfo.split('\\')[0];
-                            //console.log("GB OPERATOR type_region: ", type_region);
-                            gameCartridge_type = type_region.split(' ')[0];
-                            //console.log("GB OPERATOR gameCartridge_type: ", gameCartridge_type);
-                            gameCartridge_region = type_region.replace(gameCartridge_type,"");
-                            //finally we trim region here for later
-                            var regex = RegExp("^\\s*(.*?)\\s*$");
-                            gameCartridge_region = gameCartridge_region.replace(regex, "$1");
-                            //console.log("GB OPERATOR region: '",gameCartridge_region,"'");
-                            if(gameCartridge_region !== ""){
-                                var region_index = getRegionIndex(gameCartridge_region);
-                                if(region_index !== -1){
-                                    gameCartridge_region_regex = regionSSModel.get(region_index).regex;
-                                }
-                                else gameCartridge_region_regex = "";
-                            }
-                            else gameCartridge_region_regex = "";
+                            gameCartridge_type = ""; // NA - not really possible t well discriminate
+                            console.log("GB OPERATOR gameCartridge_type:", gameCartridge_type);
+                            gameCartridge_region = ""; // NA - not really possible t well discriminate
+                            console.log("GB OPERATOR region:",gameCartridge_region);
+                            gameCartridge_region_regex = "";
                             //check if option to save rominfo/crc32 is requested
                             if(api.internal.recalbox.getBoolParameter("dumpers.gboperator.romlist",false)){
                                 var existingFile = ""
                                 existingFile = api.internal.system.run("ls /recalbox/share/roms/gboperator.romlist.csv 2>/dev/null | tr -d '\\n' | tr -d '\\r'");
                                 if(!existingFile.includes("gboperator.romlist.csv")){
                                     //if no file exists, let create it with column titles
-                                    api.internal.system.run("echo 'GAME TITLE;REGION;TYPE;WORKS;SAVE FOUND;ROM CRC32;DUMPER VERSION;WHEN;COMMENT' >> /recalbox/share/roms/gboperator.romlist.csv");
+                                    api.internal.system.run("echo 'GAME TITLE;WORKS;SAVE FOUND;ROM CRC32;DUMPER VERSION;WHEN;COMMENT' >> /recalbox/share/roms/gboperator.romlist.csv");
                                 }
 
                                 var existingRom = ""
                                 existingRom = api.internal.system.run("grep -i " + romcrc32 + " /recalbox/share/roms/usb-nes.romlist.csv | tr -d '\\n' | tr -d '\\r'");
                                 //console.log("existingRom : ",existingRom);
                                 if(existingRom === ""){
-                                    //format GAME TITLE,REGION,TYPE,WORKS,SAVE FOUND;ROM CRC32,DUMPER VERSION,WHEN,COMMENT
+                                    //format GAME TITLE,WORKS,SAVE FOUND;ROM CRC32,DUMPER VERSION,WHEN,COMMENT
                                     var now = new Date();
                                     var formattedDateTime = now.toString("yyyy-MM-dd hh:mm:ss");
                                     //console.log("Formatted date and time:", formattedDateTime);
@@ -1409,20 +1395,19 @@ Window {
                                         //read GB OPERATOR version and store it in global variable
                                         gboperatorVersion = "1.0" // fix version for the moment, need to investigate if possible to have it from GB OPERATOR ?!
                                     }
-                                    //console.log('echo "' + rominfo + ';' + region + ';' + gameCartridge_type + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
-                                    api.internal.system.run('echo "' + rominfo + ';' + region + ';' + gameCartridge_type + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
+                                    //console.log('echo "' + rominfo + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
+                                    api.internal.system.run('echo "' + rominfo + ';' +  'Y' + ';' + savinfoflag + ';' +  romcrc32 + ';' + gboperatorVersion  + ';' + formattedDateTime + ';' + 'no comment for the moment' + '" >> /recalbox/share/roms/gboperator.romlist.csv');
 
                                 }
                             }
                             gameCartridge_system = system;
                             //to do last because will trig changes
-                            gameCartridge_crc32 = "";
-                            //remove data between [] and () in name as: (rev 1), (rev 2)
-                            regex = /\([^()]*\)|\[[^\]]*\]/;
-                            gameCartridge_name = rominfo.replace(regex, "");
+                            gameCartridge_crc32 = romcrc32.split(" ")[0];//need to take first part only because file name/path is inlcuded in result of CRC32 calculation
+                            //console.log("GBOPERATOR gameCartridge_crc32: ", gameCartridge_crc32);
+                            gameCartridge_name = rominfo;
                             //dump of rom if request
                             if(api.internal.recalbox.getBoolParameter("dumpers.gboperator.savedump",false)){
-                                var targetedDump = "/recalbox/share/dumps/" + gameCartridge_name + " (" + gameCartridge_region + ")" + " (" + gameCartridge_type + ") [" + romcrc32.split(' ')[0] + "].gb";
+                                var targetedDump = "/recalbox/share/dumps/" + gameCartridge_name  + " [" + romcrc32.split(' ')[0] + "].gb";
                                 //console.log("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                                 var existingDump = api.internal.system.run("ls '"+ targetedDump + "' 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                                 //console.log("existingDump : ",existingDump);
@@ -1635,9 +1620,18 @@ Window {
                 apiconnection.onShowPopup("Video game cartridge reader", "GB Operator plugged","",3);
             }
             else if(action.includes("gboperator-gameinserted") && api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false)){
-                apiconnection.onShowPopup("Video game cartridge reader", "GB Operator - Game inserted","",3);
+                //for test only
+                //apiconnection.onShowPopup("Video game cartridge reader", "GB Operator - Game inserted","",3);
+                dialogBoxGBOPERATORTimer.stop();
+                api.internal.system.run("rm /tmp/GBOPERATOR.readflag");
+                //start dumping animation
+                genericMessage.setSource("dialogs/GenericWaitDialog.qml",
+                                         { "title": qsTr("GB OPERATOR"), "message": qsTr("ROM is loading from reader/dumper...")});
+                genericMessage.focus = true;
             }
             else if(action.includes("gboperator-gamedumped") && api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false)){
+                //stop dumping animation
+                genericMessage.focus = false;
                 //run timer to find roms/saves from GB Operator
                 dialogBoxGBOPERATORTimer.cartridge_plugged = false;
                 dialogBoxGBOPERATORTimer.start();

--- a/src/frontend/menu/settings/GameDumperReaderSettings.qml
+++ b/src/frontend/menu/settings/GameDumperReaderSettings.qml
@@ -120,7 +120,7 @@ FocusScope {
                     width: parent.width
                     height: implicitHeight + vpx(30)
                 }
-
+				//for USBNES...
                 ToggleOption {
                     id: optUSBNESDumper
                     //dumpers.usbnes.enabled=0
@@ -204,7 +204,8 @@ FocusScope {
                     KeyNavigation.down: optRETRODEDumper
                     visible: optUSBNESDumper.checked
                 }
-                ToggleOption {
+                //for RETRODE...
+				ToggleOption {
                     id: optRETRODEDumper
                     //dumpers.retrode.enabled=0
                     SectionTitle {
@@ -254,7 +255,7 @@ FocusScope {
                     KeyNavigation.down: optRETRODESaveROMInfo
                     visible: optRETRODEDumper.checked
                 }
-                //RFU: paremeter finally not use (retroarch can't manage sav directly from cartrideg (need to rename to .srm and can't focus one file :()
+                //RFU: paremeter finally not use (retroarch can't manage sav directly from cartridge (need to rename to .srm and can't focus one file :()
                 /*ToggleOption {
                     id: optRETRODESaveReadOnly
                     //dumpers.retrode.save.readonly=1 by default
@@ -559,8 +560,88 @@ FocusScope {
                     }
                     onFocusChanged: container.onFocus(this)
                     visible: optRETRODEDumper.checked
+					KeyNavigation.down: optGBOPERATORDumper
                 }
+                //for GB OPERATOR...
+				ToggleOption {
+                    id: optGBOPERATORDumper
+                    //dumpers.gboperator.enabled=0
+                    SectionTitle {
+                        text: qsTr("GB OPERATOR dumper") + api.tr
+                        first: true
+                        symbol: "\uf264"
+                        symbolFontFamily: globalFonts.awesome
+                        symbolFontSize: vpx(40)
+                    }
 
+                    checked: api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("dumpers.gboperator.enabled",false)){
+                            api.internal.recalbox.setBoolParameter("dumpers.gboperator.enabled",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optGBOPERATORMoveSave
+                }
+                ToggleOption {
+                    id: optGBOPERATORMoveSave
+                    //dumpers.gboperator.movesave=0 by default
+                    label: qsTr("Cartridge SRAM in your saves") + api.tr
+                    note: qsTr("Move 'Save' from cartridge to play with it (if not already move)\n(Unfortunatelly retroach/usb-nes are not compatible to update SRAM directly)") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("dumpers.gboperator.movesave",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("dumpers.gboperator.movesave",false)){
+                            api.internal.recalbox.setBoolParameter("dumpers.gboperator.movesave",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optGBOPERATORSaveDump
+                    visible: optGBOPERATORDumper.checked
+                }
+                ToggleOption {
+                    id: optGBOPERATORSaveDump
+                    //dumpers.gboperator.savedump=0 by default
+                    label: qsTr("Cartridge ROM in your dumps") + api.tr
+                    note: qsTr("Copy and rename 'Rom' from cartridge to keep it\n(will be in 'dumps' share directory)") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("dumpers.gboperator.savedump",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("dumpers.gboperator.savedump",false)){
+                            api.internal.recalbox.setBoolParameter("dumpers.gboperator.savedump",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optGBOPERATORWriteSave
+                    visible: optGBOPERATORDumper.checked
+                }
+                ToggleOption {
+                    id: optGBOPERATORWriteSave
+                    //dumpers.gboperator.writesave=0 by default
+                    label: qsTr("'Save' file writing to cartridge") + api.tr
+                    note: qsTr("Enable write of save to cartridge\n(USB-NES should connected/resetted after configuration change)") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("dumpers.gboperator.writesave",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("dumpers.gboperator.writesave",false)){
+                            api.internal.recalbox.setBoolParameter("dumpers.gboperator.writesave",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optGBOPERATORSaveROMInfo
+                    visible: optGBOPERATORDumper.checked
+                }
+                ToggleOption {
+                    id: optGBOPERATORSaveROMInfo
+                    //dumpers.gboperator.romlist=0 by default
+                    label: qsTr("Save rom information in file") + api.tr
+                    note: qsTr("Enable saving of rom information identified by the dumper\n(stored in your roms directory and named 'usb-nes.romlist.csv')") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("dumpers.gboperator.romlist",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("dumpers.gboperator.romlist",false)){
+                            api.internal.recalbox.setBoolParameter("dumpers.gboperator.romlist",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    visible: optGBOPERATORDumper.checked
+                }
                 Item {
                     width: parent.width
                     height: implicitHeight + vpx(30)

--- a/src/frontend/menu/settings/GameDumperReaderSettings.qml
+++ b/src/frontend/menu/settings/GameDumperReaderSettings.qml
@@ -587,7 +587,7 @@ FocusScope {
                     id: optGBOPERATORMoveSave
                     //dumpers.gboperator.movesave=0 by default
                     label: qsTr("Cartridge SRAM in your saves") + api.tr
-                    note: qsTr("Move 'Save' from cartridge to play with it (if not already move)\n(Unfortunatelly retroach/usb-nes are not compatible to update SRAM directly)") + api.tr
+                    note: qsTr("Move 'Save' from cartridge to play with it (if not already move)\n(Unfortunatelly retroach/gboperator are not compatible to update SRAM directly)") + api.tr
                     checked: api.internal.recalbox.getBoolParameter("dumpers.gboperator.movesave",false);
                     onCheckedChanged: {
                         if(checked !== api.internal.recalbox.getBoolParameter("dumpers.gboperator.movesave",false)){
@@ -610,14 +610,15 @@ FocusScope {
                         }
                     }
                     onFocusChanged: container.onFocus(this)
-                    KeyNavigation.down: optGBOPERATORWriteSave
+                    KeyNavigation.down: optGBOPERATORSaveROMInfo
                     visible: optGBOPERATORDumper.checked
                 }
-                ToggleOption {
+                //RFU: paremeter finally not use (retroarch can't manage sav directly from cartridge (need to rename to .srm and can't focus one file :()
+                /*ToggleOption {
                     id: optGBOPERATORWriteSave
                     //dumpers.gboperator.writesave=0 by default
                     label: qsTr("'Save' file writing to cartridge") + api.tr
-                    note: qsTr("Enable write of save to cartridge\n(USB-NES should connected/resetted after configuration change)") + api.tr
+                    note: qsTr("Enable write of save to cartridge") + api.tr
                     checked: api.internal.recalbox.getBoolParameter("dumpers.gboperator.writesave",false);
                     onCheckedChanged: {
                         if(checked !== api.internal.recalbox.getBoolParameter("dumpers.gboperator.writesave",false)){
@@ -627,7 +628,7 @@ FocusScope {
                     onFocusChanged: container.onFocus(this)
                     KeyNavigation.down: optGBOPERATORSaveROMInfo
                     visible: optGBOPERATORDumper.checked
-                }
+                }*/
                 ToggleOption {
                     id: optGBOPERATORSaveROMInfo
                     //dumpers.gboperator.romlist=0 by default

--- a/src/frontend/menu/settings/GameDumperReaderSettings.qml
+++ b/src/frontend/menu/settings/GameDumperReaderSettings.qml
@@ -632,7 +632,7 @@ FocusScope {
                     id: optGBOPERATORSaveROMInfo
                     //dumpers.gboperator.romlist=0 by default
                     label: qsTr("Save rom information in file") + api.tr
-                    note: qsTr("Enable saving of rom information identified by the dumper\n(stored in your roms directory and named 'usb-nes.romlist.csv')") + api.tr
+                    note: qsTr("Enable saving of rom information identified by the dumper\n(stored in your roms directory and named 'gboperator.romlist.csv')") + api.tr
                     checked: api.internal.recalbox.getBoolParameter("dumpers.gboperator.romlist",false);
                     onCheckedChanged: {
                         if(checked !== api.internal.recalbox.getBoolParameter("dumpers.gboperator.romlist",false)){

--- a/src/frontend/menu/settings/SettingsMain.qml
+++ b/src/frontend/menu/settings/SettingsMain.qml
@@ -821,19 +821,6 @@ FocusScope {
                         root.openInformationSystem();
                     }
                     onFocusChanged: container.onFocus(this)
-                    KeyNavigation.down: optDebugMode
-                }
-                ToggleOption {
-                    id: optDebugMode
-
-                    label: qsTr("Debug mode") + api.tr
-                    note: qsTr("Give me your log baby !!! ;-)") + api.tr
-
-                    checked: api.internal.recalbox.getBoolParameter("pegasus.debuglogs")
-                    onCheckedChanged: {
-                        api.internal.recalbox.setBoolParameter("pegasus.debuglogs",checked);
-                    }
-                    onFocusChanged: container.onFocus(this)
                     KeyNavigation.down: optHideMouse
                 }
                 ToggleOption {
@@ -847,7 +834,6 @@ FocusScope {
                         api.internal.settings.mouseSupport = checked;
                     }
                     onFocusChanged: container.onFocus(this)
-                    KeyNavigation.up: optDebugMode
                     KeyNavigation.down: optHideKeyboard
                 }
                 ToggleOption {
@@ -861,12 +847,162 @@ FocusScope {
                         api.internal.settings.virtualKeyboardSupport = checked;
                     }
                     onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optDebugMode
+                }
+
+                //for Debug and logs...
+                ToggleOption {
+                    id: optDebugMode
+
+                    //label: qsTr("Debug mode") + api.tr
+                    //note: qsTr("Give me your log baby !!! ;-)") + api.tr
+
+                    SectionTitle {
+                        text: qsTr("Debug mode") + api.tr
+                        symbol: "\uf15c"
+                        first: true
+                        symbolFontFamily: globalFonts.awesome
+                        symbolFontSize: vpx(20)
+                    }
+
+                    checked: api.internal.recalbox.getBoolParameter("pegasus.debuglogs")
+                    onCheckedChanged: {
+                        api.internal.recalbox.setBoolParameter("pegasus.debuglogs",checked);
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optlogUpdate
+                }
+                ToggleOption {
+                    id: optlogUpdate
+                    label: qsTr("Hide Debug Logs for 'Updates'") + api.tr
+                    note: qsTr("to reduce log by hidding debug 'Updates' processing") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("pegasus.hide.updates.debuglogs",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("pegasus.hide.updates.debuglogs",false)){
+                            api.internal.recalbox.setBoolParameter("pegasus.hide.updates.debuglogs",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optlogScript
+                    visible: optDebugMode.checked
+                }
+                ToggleOption {
+                    id: optlogScript
+                    label: qsTr("Hide Debug Logs for 'Scripts'") + api.tr
+                    note: qsTr("to reduce log by hidding 'Scripts' processing") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("pegasus.hide.scripts.debuglogs",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("pegasus.hide.scripts.debuglogs",false)){
+                            api.internal.recalbox.setBoolParameter("pegasus.hide.scripts.debuglogs",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optlogController
+                    visible: optDebugMode.checked
+                }
+                ToggleOption {
+                    id: optlogController
+                    label: qsTr("Hide Debug Logs for 'Controller'") + api.tr
+                    note: qsTr("to reduce log by hidding 'Controller' processing") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("pegasus.hide.controller.debuglogs",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("pegasus.hide.controller.debuglogs",false)){
+                            api.internal.recalbox.setBoolParameter("pegasus.hide.controller.debuglogs",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optlogQml
+                    visible: optDebugMode.checked
+                }
+                ToggleOption {
+                    id: optlogQml
+                    label: qsTr("Hide Debug Logs for 'Qml'") + api.tr
+                    note: qsTr("to reduce log by hidding 'Qml' processing") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("pegasus.hide.qml.debuglogs",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("pegasus.hide.qml.debuglogs",false)){
+                            api.internal.recalbox.setBoolParameter("pegasus.hide.qml.debuglogs",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optlogPulseAudio
+                    visible: optDebugMode.checked
+                }
+                ToggleOption {
+                    id: optlogPulseAudio
+                    label: qsTr("Hide Debug Logs for 'PulseAudio'") + api.tr
+                    note: qsTr("to reduce log by hidding 'PulseAudio' processing") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("pegasus.hide.pulseaudio.debuglogs",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("pegasus.hide.pulseaudio.debuglogs",false)){
+                            api.internal.recalbox.setBoolParameter("pegasus.hide.pulseaudio.debuglogs",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optlogRetroachievements
+                    visible: optDebugMode.checked
+                }
+                ToggleOption {
+                    id: optlogRetroachievements
+                    label: qsTr("Hide Debug Logs for 'Retroachievements'") + api.tr
+                    note: qsTr("to reduce log by hidding 'Retroachievements' processing") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("pegasus.hide.retroachievements.debuglogs",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("pegasus.hide.retroachievements.debuglogs",false)){
+                            api.internal.recalbox.setBoolParameter("pegasus.hide.retroachievements.debuglogs",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optlogGamelist
+                    visible: optDebugMode.checked
+                }
+                ToggleOption {
+                    id: optlogGamelist
+                    label: qsTr("Hide Debug Logs for 'Gamelist'") + api.tr
+                    note: qsTr("to reduce log by hidding 'Gamelist' processing") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("pegasus.hide.gamelist.debuglogs",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("pegasus.hide.gamelist.debuglogs",false)){
+                            api.internal.recalbox.setBoolParameter("pegasus.hide.gamelist.debuglogs",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optlogGamepadManagerSDL2
+                    visible: optDebugMode.checked
+                }
+                ToggleOption {
+                    id: optlogGamepadManagerSDL2
+                    label: qsTr("Hide Debug Logs for 'GamepadManagerSDL2'") + api.tr
+                    note: qsTr("to reduce log by hidding 'GamepadManagerSDL2' processing") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("pegasus.hide.gamepadmanagersdl2.debuglogs",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("pegasus.hide.gamepadmanagersdl2.debuglogs",false)){
+                            api.internal.recalbox.setBoolParameter("pegasus.hide.gamepadmanagersdl2.debuglogs",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optlogAudioDevice
+                    visible: optDebugMode.checked
+                }
+                ToggleOption {
+                    id: optlogAudioDevice
+                    label: qsTr("Hide Debug Logs for 'AudioDevice'") + api.tr
+                    note: qsTr("to reduce log by hidding 'AudioDevice' processing") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("pegasus.hide.audiodevice.debuglogs",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("pegasus.hide.audiodevice.debuglogs",false)){
+                            api.internal.recalbox.setBoolParameter("pegasus.hide.audiodevice.debuglogs",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
                     KeyNavigation.down: optShowLogs
+                    visible: optDebugMode.checked
                 }
                 SectionTitle {
                     text: qsTr("Developer menu") + api.tr
-                    first: true
-                    symbol: "\uf412" //TODO: change icon ?!
+                    symbol: "\uf2ed"
+                    symbolFontFamily: globalFonts.awesome
+                    symbolFontSize: vpx(60)
                     visible: devModeActivated
                 }
                 SimpleButton {


### PR DESCRIPTION
	- introduce support of Epilogie GB Operator dumper/reader:
		- add section for "actions" linked to this reader/dumper
		- introduction timer for gboperator rom/save management
		- add settings menu for this dumper/reader
		- add capacity to hide some usual verbose debug logs
		- add systemName in "Singleplay" notifications
		- stable and tested for launch/dump of GB/GBC cartridge
		- update dumper logs for debug logs
		- keep header info in romlist csv file
		- fix sublabel about gboperator.romlist.csv
		- remove some singleplay debug log
		- add management of saves
		- fix extension of dump files
		- fix to manage game with ' in file name
		- remove save file writing not supported by retroarch/gboperator for the moment
		- fix management of saves
		- add management of dedicated libretro core directory for saves