### PR TITLE
'Save' feature improvements for dumpers (retrode/gb operator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file (focus on ch
 	- quick fix to force bluetooth scan in all cases now
 
 - Features:
-	- intriduction of dedicaced view for wine and proton configuration (to share with all emulators using wine):
+	- introduction of dedicaced view for wine and proton configuration (to share with all emulators using wine):
 		- add management of DLL overrides
 		- remove also bottles from saves/usersettings stored in a NAS for example
 		- add wine version for wine engines
@@ -124,9 +124,11 @@ All notable changes to this project will be documented in this file (focus on ch
 		- add management of saves
 		- fix extension of dump files
 		- fix to manage game with ' in file name
-		- remove save file writing not supported by retroarch/gboperator for the moment
 		- fix management of saves
 		- add management of dedicated libretro core directory for saves
+		- finally add save writing in cartridge using binding for gb operator and retrode
+		- stop to use "extractions" directory for retrode/gb operator
+		- improve bind/cp for saves writing
 	- for dev ;-):
 		- introduction log viewer - first iteration
 	- display Advanced Emulator Settings if emulator present for some cases.

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -816,14 +816,17 @@ Window {
                 else{
                     targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + romName + savExt;
                 }
-                existingSave = api.internal.system.run("ls \""+ targetedSave + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                 //umount first (to remove existing bind in all cases)
                 api.internal.system.run("umount \"" + targetedSave + "\"");
+                api.internal.system.run("sleep 0.5");
+                existingSave = api.internal.system.run("ls \""+ targetedSave + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
+                //console.log("existingSave: ", existingSave);
                 if(api.internal.recalbox.getBoolParameter("dumpers." + gameCartridge_dumper + ".movesave",false)){
                     //manual move/erase to do in share saves directory if needed
                     if(!existingSave.includes("/recalbox/share/saves/")){
                         //copy of save
                         api.internal.system.run("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
+                        //console.log("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
                     }
                 }
                 if(api.internal.recalbox.getBoolParameter("dumpers." + gameCartridge_dumper + ".writesave",false)){
@@ -831,9 +834,12 @@ Window {
                     if(!existingSave.includes("/recalbox/share/saves/")){
                         //copy of save to have a initial file in all cases
                         api.internal.system.run("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
+                        //console.log("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
+                        api.internal.system.run("sleep 0.5");
                     }
                     //use BIND to have same behavior than symlink but on all file system
                     api.internal.system.run("mount --bind \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
+                    //console.log("mount --bind \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
                 }
             }
             // connect game to launcher

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -808,31 +808,13 @@ Window {
                 //force every save file to use .srm extension for the moment when we move it and use it with in retroarch
                 var savExt = ".srm";
 
-                //RFU
-                // Apply the regular expression to the file name
-                //match = regex.exec(filename);
-                // If a match is found, extract the file name and extension
-                //var savExt = "";
-                //var savName = "";
-                //if (match) {
-                //    savName = match[1];
-                //    savExt = match[2];
-                //}
-
-                targetedRom = "/recalbox/share/extractions/" + romName + " [" + romcrc32.split(' ')[0] + "]" + romExt;
-                //mandatory copy of rom in /extractions to be able to rename rom nd to match with targeted save file (we will erase in this case if already exists)
-                //copy of rom
-                api.internal.system.run("cp \"" + gameCartridge_rom + "\" \"" + targetedRom + "\"");
-                //need to reset rom full path in this case
-                api.internal.singleplay.setFile(targetedRom);
-
                 //for the moment: we don't recopy save if already exists for this rom / no proposal to erase in this case
                 if(api.internal.singleplay.getEmulatorName() === "libretro"){
                     coreLongName = api.internal.singleplay.getCoreLongName();
-                    targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + coreLongName + "/" + romName + " [" + romcrc32.split(' ')[0] + "]" + savExt;
+                    targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + coreLongName + "/" + romName + savExt;
                 }
                 else{
-                    targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + romName + " [" + romcrc32.split(' ')[0] + "]" + savExt;
+                    targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + romName + savExt;
                 }
                 existingSave = api.internal.system.run("ls \""+ targetedSave + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
                 //umount first (to remove existing bind in all cases)

--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -782,8 +782,9 @@ Window {
             }
             //For retrode & gb operator case (using multiple systems) and not as usbnes ;-)
             else if((gameCartridge_save !== "")
-                    && ( ((gameCartridge_dumper === "retrode") && api.internal.recalbox.getBoolParameter("dumpers.retrode.movesave",false))
-                    ||   ((gameCartridge_dumper === "gboperator") && api.internal.recalbox.getBoolParameter("dumpers.gboperator.movesave",false)) )
+                    && ((gameCartridge_dumper === "retrode") || (gameCartridge_dumper === "gboperator"))
+                    && ( api.internal.recalbox.getBoolParameter("dumpers." + gameCartridge_dumper + ".movesave",false)
+                      || api.internal.recalbox.getBoolParameter("dumpers." + gameCartridge_dumper + ".writesave",false))
                     ){
                 //get crc32 to ahve it in name of files as reference to improve unicity
                 if(gameCartridge_dumper === "retrode") romcrc32 = api.internal.system.run("cat /tmp/RETRODE.romcrc32 | tr -d '\\n' | tr -d '\\r'");
@@ -834,12 +835,24 @@ Window {
                     targetedSave = "/recalbox/share/saves/" + gameCartridge_system + "/" + romName + " [" + romcrc32.split(' ')[0] + "]" + savExt;
                 }
                 existingSave = api.internal.system.run("ls \""+ targetedSave + "\" 2>/dev/null  | tr -d '\\n' | tr -d '\\r'");
-                //manual move/erase to do in share saves directory in this case
-                if(!existingSave.includes("/recalbox/share/saves/")){
-                    //copy of save
-                    api.internal.system.run("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
+                //umount first (to remove existing bind in all cases)
+                api.internal.system.run("umount \"" + targetedSave + "\"");
+                if(api.internal.recalbox.getBoolParameter("dumpers." + gameCartridge_dumper + ".movesave",false)){
+                    //manual move/erase to do in share saves directory if needed
+                    if(!existingSave.includes("/recalbox/share/saves/")){
+                        //copy of save
+                        api.internal.system.run("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
+                    }
                 }
-
+                if(api.internal.recalbox.getBoolParameter("dumpers." + gameCartridge_dumper + ".writesave",false)){
+                    //create like a symlink to update cartridge directly (or from /tmp in case of gb operator)
+                    if(!existingSave.includes("/recalbox/share/saves/")){
+                        //copy of save to have a initial file in all cases
+                        api.internal.system.run("cp \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
+                    }
+                    //use BIND to have same behavior than symlink but on all file system
+                    api.internal.system.run("mount --bind \"" + gameCartridge_save + "\" \"" + targetedSave + "\"");
+                }
             }
             // connect game to launcher
             api.connectGameFiles(api.internal.singleplay.game);

--- a/src/frontend/menu/settings/GameDumperReaderSettings.qml
+++ b/src/frontend/menu/settings/GameDumperReaderSettings.qml
@@ -40,6 +40,8 @@ FocusScope {
                 api.internal.system.run("sed -i 's/\\[forceSize\\].*/\\[forceSize\\] " + api.internal.recalbox.getIntParameter("dumpers.retrode.force.size",0) + "/g' /tmp/RETRODE.CFG");
                 //update Force Mapper
                 api.internal.system.run("sed -i 's/\\[forceMapper\\].*/\\[forceMapper\\] " + api.internal.recalbox.getIntParameter("dumpers.retrode.force.mapper",0) + "/g' /tmp/RETRODE.CFG");
+                //update Save Read Only
+                api.internal.system.run("sed -i 's/\\[saveReadonly\\].*/\\[saveReadonly\\] " + ( api.internal.recalbox.getIntParameter("dumpers.retrode.writesave",0) === 1 ? "0" : "1" ) + "/g' /tmp/RETRODE.CFG");
                 //recopy now from TMP to mountPoint and sync to be sure about udpate ;-)
                 api.internal.system.run("dd if=/tmp/RETRODE.CFG of=" + mountpoint + "/RETRODE.CFG");
             }
@@ -228,8 +230,8 @@ FocusScope {
                 ToggleOption {
                     id: optRETRODEMoveSave
                     //dumpers.retrode.movesave=0 by default
-                    label: qsTr("Cartridge SRAM in your saves") + api.tr
-                    note: qsTr("Move 'Save' from cartridge to play with it (if not already move)\n(Unfortunatelly retroach/retrode are not compatible to update SRAM directly)") + api.tr
+                    label: qsTr("Cartridge RAM in your saves") + api.tr
+                    note: qsTr("Moved .sav from cartridge to your .srm saves to play with it (if not already moved/exists)") + api.tr
                     checked: api.internal.recalbox.getBoolParameter("dumpers.retrode.movesave",false);
                     onCheckedChanged: {
                         if(checked !== api.internal.recalbox.getBoolParameter("dumpers.retrode.movesave",false)){
@@ -237,8 +239,23 @@ FocusScope {
                         }
                     }
                     onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optRETRODEWriteSave
+                    visible: optRETRODEDumper.checked && !optRETRODEWriteSave.checked
+                }
+                ToggleOption {
+                    id: optRETRODEWriteSave
+                    //dumpers.retrode.writesave=0 by default
+                    label: qsTr("Cartridge RAM writing (Beta)") + api.tr
+                    note: qsTr("Create link from your saves to cartridge (if not already moved/exists)") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("dumpers.retrode.writesave",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("dumpers.retrode.writesave",false)){
+                            api.internal.recalbox.setBoolParameter("dumpers.retrode.writesave",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
                     KeyNavigation.down: optRETRODESaveDump
-                    visible: optRETRODEDumper.checked
+                    visible: optRETRODEDumper.checked && !optRETRODEMoveSave.checked
                 }
                 ToggleOption {
                     id: optRETRODESaveDump
@@ -255,38 +272,6 @@ FocusScope {
                     KeyNavigation.down: optRETRODESaveROMInfo
                     visible: optRETRODEDumper.checked
                 }
-                //RFU: paremeter finally not use (retroarch can't manage sav directly from cartridge (need to rename to .srm and can't focus one file :()
-                /*ToggleOption {
-                    id: optRETRODESaveReadOnly
-                    //dumpers.retrode.save.readonly=1 by default
-                    label: qsTr("Cartridge SRAM readonly") + api.tr
-                    note: qsTr("Deactivate readonly to save directly in cartridge\n(see also RETRODE documentation to know 'save support' by system)") + api.tr
-                    checked: api.internal.recalbox.getBoolParameter("dumpers.retrode.save.readonly",true);
-                    onCheckedChanged: {
-                        if(checked !== api.internal.recalbox.getBoolParameter("dumpers.retrode.save.readonly",true)){
-                            api.internal.recalbox.setBoolParameter("dumpers.retrode.save.readonly",checked);
-                        }
-                    }
-                    onFocusChanged: container.onFocus(this)
-                    KeyNavigation.down: optRETRODEfilenameChecksum
-                    visible: optRETRODEDumper.checked && !optRETRODEMoveSave.checked
-                }*/
-                //RFU: no usage of this feature for the moment
-                /*ToggleOption {
-                    id: optRETRODEfilenameChecksum
-                    //dumpers.retrode.filename.checksum=1 by default
-                    label: qsTr("Checksum/Game Code in file name") + api.tr
-                    note: qsTr("Add 4-digit checksum or game code in rom file name\n(see RETRODE documentation for more details on this parameter)") + api.tr
-                    checked: api.internal.recalbox.getBoolParameter("dumpers.retrode.filename.checksum",true);
-                    onCheckedChanged: {
-                        if(checked !== api.internal.recalbox.getBoolParameter("dumpers.retrode.filename.checksum",true)){
-                            api.internal.recalbox.setBoolParameter("dumpers.retrode.filename.checksum",checked);
-                        }
-                    }
-                    onFocusChanged: container.onFocus(this)
-                    KeyNavigation.down: optRETRODESaveROMInfo
-                    visible: optRETRODEDumper.checked
-                }*/
                 ToggleOption {
                     id: optRETRODESaveROMInfo
                     //dumpers.retrode.romlist=0 by default
@@ -601,7 +586,7 @@ FocusScope {
                 ToggleOption {
                     id: optGBOPERATORWriteSave
                     //dumpers.gboperator.writesave=0 by default
-                    label: qsTr("Cartridge RAM writing") + api.tr
+                    label: qsTr("Cartridge RAM writing (Beta)") + api.tr
                     note: qsTr("Create symlink from your saves to cartridge (if not already moved/exists)") + api.tr
                     checked: api.internal.recalbox.getBoolParameter("dumpers.gboperator.writesave",false);
                     onCheckedChanged: {

--- a/src/frontend/menu/settings/GameDumperReaderSettings.qml
+++ b/src/frontend/menu/settings/GameDumperReaderSettings.qml
@@ -586,8 +586,8 @@ FocusScope {
                 ToggleOption {
                     id: optGBOPERATORMoveSave
                     //dumpers.gboperator.movesave=0 by default
-                    label: qsTr("Cartridge SRAM in your saves") + api.tr
-                    note: qsTr("Move 'Save' from cartridge to play with it (if not already move)\n(Unfortunatelly retroach/gboperator are not compatible to update SRAM directly)") + api.tr
+                    label: qsTr("Cartridge RAM in your saves") + api.tr
+                    note: qsTr("Moved .sav from cartridge to your .srm saves to play with it (if not already moved/exists)") + api.tr
                     checked: api.internal.recalbox.getBoolParameter("dumpers.gboperator.movesave",false);
                     onCheckedChanged: {
                         if(checked !== api.internal.recalbox.getBoolParameter("dumpers.gboperator.movesave",false)){
@@ -595,8 +595,23 @@ FocusScope {
                         }
                     }
                     onFocusChanged: container.onFocus(this)
+                    KeyNavigation.down: optGBOPERATORWriteSave
+                    visible: optGBOPERATORDumper.checked && !optGBOPERATORWriteSave.checked
+                }
+                ToggleOption {
+                    id: optGBOPERATORWriteSave
+                    //dumpers.gboperator.writesave=0 by default
+                    label: qsTr("Cartridge RAM writing") + api.tr
+                    note: qsTr("Create symlink from your saves to cartridge (if not already moved/exists)") + api.tr
+                    checked: api.internal.recalbox.getBoolParameter("dumpers.gboperator.writesave",false);
+                    onCheckedChanged: {
+                        if(checked !== api.internal.recalbox.getBoolParameter("dumpers.gboperator.writesave",false)){
+                            api.internal.recalbox.setBoolParameter("dumpers.gboperator.writesave",checked);
+                        }
+                    }
+                    onFocusChanged: container.onFocus(this)
                     KeyNavigation.down: optGBOPERATORSaveDump
-                    visible: optGBOPERATORDumper.checked
+                    visible: optGBOPERATORDumper.checked && !optGBOPERATORMoveSave.checked
                 }
                 ToggleOption {
                     id: optGBOPERATORSaveDump
@@ -613,22 +628,6 @@ FocusScope {
                     KeyNavigation.down: optGBOPERATORSaveROMInfo
                     visible: optGBOPERATORDumper.checked
                 }
-                //RFU: paremeter finally not use (retroarch can't manage sav directly from cartridge (need to rename to .srm and can't focus one file :()
-                /*ToggleOption {
-                    id: optGBOPERATORWriteSave
-                    //dumpers.gboperator.writesave=0 by default
-                    label: qsTr("'Save' file writing to cartridge") + api.tr
-                    note: qsTr("Enable write of save to cartridge") + api.tr
-                    checked: api.internal.recalbox.getBoolParameter("dumpers.gboperator.writesave",false);
-                    onCheckedChanged: {
-                        if(checked !== api.internal.recalbox.getBoolParameter("dumpers.gboperator.writesave",false)){
-                            api.internal.recalbox.setBoolParameter("dumpers.gboperator.writesave",checked);
-                        }
-                    }
-                    onFocusChanged: container.onFocus(this)
-                    KeyNavigation.down: optGBOPERATORSaveROMInfo
-                    visible: optGBOPERATORDumper.checked
-                }*/
                 ToggleOption {
                     id: optGBOPERATORSaveROMInfo
                     //dumpers.gboperator.romlist=0 by default


### PR DESCRIPTION
Improvements:
		- finally add save writing in cartridge using binding for gb operator and retrode
		- stop to use "extractions" directory for retrode/gb operator
		- improve bind/cp for saves writing